### PR TITLE
WiFi lib: Refactoring for"status" state machine. Function renaming. Added gatewayIP and hostByName().

### DIFF
--- a/libraries/WiFi/src/SecSocket.cpp
+++ b/libraries/WiFi/src/SecSocket.cpp
@@ -180,7 +180,7 @@ uint16_t Socket::port() {
     return _port;
 }
 
-int Socket::hostByName(const char* aHostname, IPAddress& aResult) {
+int Socket::hostByName(const char* aHostname, IPAddress& ip) {
     cy_socket_sockaddr_t address;
     
     cy_rslt_t ret = cy_socket_gethostbyname(aHostname, CY_SOCKET_IP_VER_V4, &(address.ip_address));
@@ -188,7 +188,7 @@ int Socket::hostByName(const char* aHostname, IPAddress& aResult) {
         return SOCKET_STATUS_ERROR;
     }
 
-    aResult = IPAddress(address.ip_address.ip.v4);
+    ip = IPAddress(address.ip_address.ip.v4);
 
     return true;
 }

--- a/libraries/WiFi/src/SecSocket.cpp
+++ b/libraries/WiFi/src/SecSocket.cpp
@@ -41,23 +41,23 @@ void Socket::end() {
     _last_error = Socket::global_sockets_deinit();
 }
 
-void Socket::set_timeout(uint32_t timeout) {
+void Socket::setTimeout(uint32_t timeout) {
     _last_error = cy_socket_setsockopt(socket, CY_SOCKET_SOL_SOCKET,
                                     CY_SOCKET_SO_RCVTIMEO, &timeout,
                                     sizeof(timeout)); 
     socket_assert(_last_error);
 }
 
-void Socket::set_connect_opt_callback(cy_socket_callback_t cback, void * arg) {
-    set_opt_callback(CY_SOCKET_SO_CONNECT_REQUEST_CALLBACK, cback, arg);
+void Socket::setConnectOptCallback(cy_socket_callback_t cback, void * arg) {
+    setOptCallback(CY_SOCKET_SO_CONNECT_REQUEST_CALLBACK, cback, arg);
 }
 
-void Socket::set_receive_opt_callback(cy_socket_callback_t cback, void * arg) {
-    set_opt_callback(CY_SOCKET_SO_RECEIVE_CALLBACK, cback, arg);
+void Socket::setReceiveOptCallback(cy_socket_callback_t cback, void * arg) {
+    setOptCallback(CY_SOCKET_SO_RECEIVE_CALLBACK, cback, arg);
 }
 
-void Socket::set_disconnect_opt_callback(cy_socket_callback_t cback, void * arg) {
-    set_opt_callback(CY_SOCKET_SO_DISCONNECT_CALLBACK, cback, arg);
+void Socket::setDisconnectOptCallback(cy_socket_callback_t cback, void * arg) {
+    setOptCallback(CY_SOCKET_SO_DISCONNECT_CALLBACK, cback, arg);
 }
 
 void Socket::bind(uint16_t port) {
@@ -197,7 +197,7 @@ uint8_t Socket::status() {
     return _status;
 }   
 
-cy_rslt_t Socket::get_last_error() {
+cy_rslt_t Socket::getLastError() {
     return _last_error;
 }   
 
@@ -231,7 +231,7 @@ void Socket::receiveCallback() {
     }
 }
 
-void Socket::set_opt_callback(int optname, cy_socket_callback_t cback, void * arg) {
+void Socket::setOptCallback(int optname, cy_socket_callback_t cback, void * arg) {
     cy_socket_opt_callback_t cy_opt_callback;
 
     cy_opt_callback.callback = cback; 

--- a/libraries/WiFi/src/SecSocket.cpp
+++ b/libraries/WiFi/src/SecSocket.cpp
@@ -180,6 +180,19 @@ uint16_t Socket::port() {
     return _port;
 }
 
+int Socket::hostByName(const char* aHostname, IPAddress& aResult) {
+    cy_socket_sockaddr_t address;
+    
+    cy_rslt_t ret = cy_socket_gethostbyname(aHostname, CY_SOCKET_IP_VER_V4, &(address.ip_address));
+    if(ret != CY_RSLT_SUCCESS) {
+        return SOCKET_STATUS_ERROR;
+    }
+
+    aResult = IPAddress(address.ip_address.ip.v4);
+
+    return true;
+}
+
 uint8_t Socket::status() {
     return _status;
 }   

--- a/libraries/WiFi/src/SecSocket.h
+++ b/libraries/WiFi/src/SecSocket.h
@@ -1,5 +1,3 @@
-
-
 #ifndef CY_SECURE_SOCKET_H
 #define CY_SECURE_SOCKET_H
 
@@ -27,10 +25,10 @@ public:
     void begin();
     void end();
 
-    void set_timeout(uint32_t timeout);
-    void set_connect_opt_callback(cy_socket_callback_t cback, void *arg);
-    void set_receive_opt_callback(cy_socket_callback_t cback, void *arg);
-    void set_disconnect_opt_callback(cy_socket_callback_t cback, void *arg);
+    void setTimeout(uint32_t timeout);
+    void setConnectOptCallback(cy_socket_callback_t cback, void *arg);
+    void setReceiveOptCallback(cy_socket_callback_t cback, void *arg);
+    void setDisconnectOptCallback(cy_socket_callback_t cback, void *arg);
 
     void bind(uint16_t port);
     bool connect(IPAddress ip, uint16_t port);
@@ -47,8 +45,10 @@ public:
     IPAddress remoteIP();
     uint16_t port();
 
+    static int hostByName(const char *aHostname, IPAddress& ip);
+
     uint8_t status();
-    cy_rslt_t get_last_error();
+    cy_rslt_t getLastError();
 
 private:
 
@@ -59,7 +59,7 @@ private:
     IPAddress remote_ip;
     uint16_t _port;
 
-    void set_opt_callback(int optname, cy_socket_callback_t cback, void *arg);
+    void setOptCallback(int optname, cy_socket_callback_t cback, void *arg);
 
     static const uint16_t RX_BUFFER_SIZE = 256;
     arduino::RingBufferN < RX_BUFFER_SIZE > rx_buf;

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -12,6 +12,11 @@
         return ret_code; \
 }
 
+#define wifi_assert(cy_ret, ret_code)   if (cy_ret != CY_RSLT_SUCCESS) { \
+        _status = ret_code; \
+        return; \
+}
+
 WiFiClass & WiFiClass::get_instance() {
     static WiFiClass wifi_singleton;
     return wifi_singleton;
@@ -102,6 +107,33 @@ uint8_t WiFiClass::beginAP(const char *ssid, const char* passphrase, uint8_t cha
     _status = WL_AP_CONNECTED;
 
     return WL_AP_CONNECTED;
+}
+
+void WiFiClass::config(IPAddress local_ip) {
+
+}
+
+void WiFiClass::config(IPAddress local_ip, IPAddress dns_server) {
+
+}
+
+void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway) {
+
+}
+
+void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet) {
+
+    //for STA
+        // if connected disconnect
+        // is there some current settings for IP
+            // change the IP as provided
+            // connect to ap again if it was connected 
+            // else just keep the settings for when the user decides to connect
+            
+        // is there current setting for DNS? 
+
+    //for AP
+        //just call the provided function.
 }
 
 IPAddress WiFiClass::localIP() {

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -1,4 +1,5 @@
 #include <WiFi.h>
+#include "Socket.h"
 
 /** 
  * @brief Macro to assert the return value of the cy_wcm APIs 
@@ -137,6 +138,10 @@ IPAddress WiFiClass::gatewayIP() {
 uint8_t WiFiClass::status() {
     return _status;
 }
+
+int WiFiClass::hostByName(const char* aHostname, IPAddress& aResult) {
+    return Socket::hostByName(aHostname, aResult);
+}   
 
 WiFiClass::WiFiClass() {
 

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -171,8 +171,8 @@ uint8_t WiFiClass::status() {
     return _status;
 }
 
-int WiFiClass::hostByName(const char* aHostname, IPAddress& aResult) {
-    return Socket::hostByName(aHostname, aResult);
+int WiFiClass::hostByName(const char* aHostname, IPAddress& ip) {
+    return Socket::hostByName(aHostname, ip);
 }   
 
 WiFiClass::WiFiClass() {

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -103,8 +103,7 @@ uint8_t WiFiClass::beginAP(const char *ssid, const char* passphrase, uint8_t cha
     return WL_AP_CONNECTED;
 }
 
-IPAddress WiFiClass::localIP()
-{
+IPAddress WiFiClass::localIP() {
     /* If the WiFi interface has not been yet initialized. */
     if(_mode == CY_WCM_INTERFACE_TYPE_UNKNOWN) {
         return IPAddress(0, 0, 0, 0);
@@ -120,10 +119,24 @@ IPAddress WiFiClass::localIP()
     return ip;
 }
 
+IPAddress WiFiClass::gatewayIP() {
+    if(_mode == CY_WCM_INTERFACE_TYPE_UNKNOWN) {
+        return IPAddress(0, 0, 0, 0);
+    }
+
+    cy_wcm_ip_address_t gateway_ip;
+    cy_rslt_t ret = cy_wcm_get_gateway_ip_address(_mode, &gateway_ip);
+    if(ret != CY_RSLT_SUCCESS) {
+        return IPAddress(0, 0, 0, 0);
+    }
+
+    IPAddress ip(gateway_ip.ip.v4);
+    return ip;
+};
+
 uint8_t WiFiClass::status() {
     return _status;
 }
-
 
 WiFiClass::WiFiClass() {
 

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -97,7 +97,7 @@ uint8_t WiFiClass::beginAP(const char *ssid, const char* passphrase, uint8_t cha
         ap_conf.ap_credentials.security = CY_WCM_SECURITY_OPEN;
     }
 
-    /* The AP requires a default some default IP settings */
+    /* The AP requires some default IP settings */
     cy_wcm_set_ap_ip_setting(&(ap_conf.ip_settings), "192.168.0.1", "255.255.255.0", "192.168.0.1", CY_WCM_IP_VER_V4);
 
     ret = cy_wcm_start_ap(&ap_conf);

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -10,7 +10,11 @@
 #include "cy_wcm.h"
 
 /**
+<<<<<<< HEAD
  * TODOs:
+=======
+ * TODO: 
+>>>>>>> 391752a (libraries/WiFi/src/WiFi: Added gatewayIP() function.)
  *  - Adapt the enum list conveniently. Do we need to keep all?
  *  - Move it to some header file?
 */
@@ -80,22 +84,29 @@ public:
     */
     IPAddress localIP();
 
+    /*
+    * Get the gateway IP address.
+    *
+    * return: gateway IP address value
+    */
+    IPAddress gatewayIP();
+
     /**
-     * Return Connection status
-     * TODO: Clean up unused or irrelevant status codes for this core.
-     *
-     *  WL_CONNECTED: assigned when connected to a WiFi network;
-     *  WL_AP_CONNECTED : assigned when a device is connected in Access Point mode;
-     *  WL_AP_LISTENING : assigned when the listening for connections in Access Point mode;
-     *  WL_NO_SHIELD: assigned when no WiFi shield is present;
-     *  WL_NO_MODULE: assigned when the communication with an integrated WiFi module fails;
-     *  WL_IDLE_STATUS: it is a temporary status assigned when WiFi.begin() is called and remains active until the number of attempts expires (resulting in WL_CONNECT_FAILED) or a connection is established (resulting in WL_CONNECTED);
-     *  WL_NO_SSID_AVAIL: assigned when no SSID are available;
-     *  WL_SCAN_COMPLETED: assigned when the scan networks is completed;
-     *  WL_CONNECT_FAILED: assigned when the connection fails for all the attempts;
-     *  WL_CONNECTION_LOST: assigned when the connection is lost;
-     *  WL_DISCONNECTED: assigned when disconnected from a network;
-     */
+        * Return Connection status
+        * TODO: Clean up unused or irrelevant status codes for this core.
+        * 
+        *  WL_CONNECTED: assigned when connected to a WiFi network;
+        *  WL_AP_CONNECTED : assigned when a device is connected in Access Point mode;
+        *  WL_AP_LISTENING : assigned when the listening for connections in Access Point mode;
+        *  WL_NO_SHIELD: assigned when no WiFi shield is present;
+        *  WL_NO_MODULE: assigned when the communication with an integrated WiFi module fails;
+        *  WL_IDLE_STATUS: it is a temporary status assigned when WiFi.begin() is called and remains active until the number of attempts expires (resulting in WL_CONNECT_FAILED) or a connection is established (resulting in WL_CONNECTED);
+        *  WL_NO_SSID_AVAIL: assigned when no SSID are available;
+        *  WL_SCAN_COMPLETED: assigned when the scan networks is completed;
+        *  WL_CONNECT_FAILED: assigned when the connection fails for all the attempts;
+        *  WL_CONNECTION_LOST: assigned when the connection is lost;
+        *  WL_DISCONNECTED: assigned when disconnected from a network;
+        */
     uint8_t status();
 
 private:

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -116,7 +116,7 @@ class WiFiClass {
          */
         uint8_t status();
 
-        int hostByName(const char* aHostname, IPAddress& aResult);
+        int hostByName(const char* aHostname, IPAddress& ip);
 
     private: 
 

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -10,7 +10,7 @@
 #include "cy_wcm.h"
 
 /**
- * TODO: 
+ * TODO:
  *  - Adapt the enum list conveniently. Do we need to keep all?
  *  - Move it to some header file?
 */
@@ -29,118 +29,131 @@ typedef enum {
     WL_AP_FAILED
 } wl_status_t;
 
+typedef enum {
+    WIFI_STATUS_UNINITED = 0,
+    WIFI_STATUS_INITED = WL_IDLE_STATUS,
+    WIFI_STATUS_STA_CONNECTED = WL_CONNECTED,
+    WIFI_STATUS_AP_CONNECTED = WL_AP_LISTENING,
+    WIFI_STATUS_STA_DISCONNECTED = WL_DISCONNECTED,
+    WIFI_STATUS_AP_DISCONNECTED = WIFI_STATUS_INITED
+} wifi_status_t;
+
+typedef enum {
+    WIFI_ERROR_NONE = 0,
+    WIFI_ERROR_INIT_FAILED = WL_NO_SHIELD,
+    WIFI_ERROR_STA_CONNECT_FAILED = WL_CONNECT_FAILED,
+    WIFI_ERROR_AP_LISTENING_FAILED = WL_AP_FAILED,
+    WIFI_ERROR_STA_AP_MODE_INCOMPATIBLE,
+    WIFI_ERROR_STATUS_INVALID
+} wifi_error_t;
+
 class WiFiClass {
 
-    public:
+public:
 
-        /* Return the WiFi class singleton */
-        static WiFiClass & get_instance();
+    /* Return the WiFi class singleton */
+    static WiFiClass & get_instance();
 
-        /* Start Wifi connection for OPEN networks
-        *
-        * param ssid: Pointer to the SSID string.
-        */
-        int begin(const char *ssid);
+    /* Start Wifi connection for OPEN networks
+    *
+    * param ssid: Pointer to the SSID string.
+    */
+    int begin(const char *ssid);
 
-        /* Start WiFi connection with passphrase
-        * the most secure supported mode will be automatically selected
-        *
-        * param ssid: Pointer to the SSID string.
-        * param passphrase: Passphrase. Valid characters in a passphrase
-        *        must be between ASCII 32-126 (decimal).
-        */
-        int begin(const char *ssid, const char *passphrase);
+    /* Start WiFi connection with passphrase
+    * the most secure supported mode will be automatically selected
+    *
+    * param ssid: Pointer to the SSID string.
+    * param passphrase: Passphrase. Valid characters in a passphrase
+    *        must be between ASCII 32-126 (decimal).
+    */
+    int begin(const char *ssid, const char *passphrase);
 
-        /* WEP is not supported by WCM class as considered an insecure encryption. */
+    /* WEP is not supported by WCM class as considered an insecure encryption. */
 
-        // /* Start WiFi connection with WEP encryption.
-        // * Configure a key into the device. The key type (WEP-40, WEP-104)
-        // * is determined by the size of the key (5 bytes for WEP-40, 13 bytes for WEP-104).
-        // *
-        // * param ssid: Pointer to the SSID string.
-        // * param key_idx: The key index to set. Valid values are 0-3.
-        // * param key: Key input buffer.
-        // */
-        // int begin(const char* ssid, uint8_t key_idx, const char* key);
+    // /* Start WiFi connection with WEP encryption.
+    // * Configure a key into the device. The key type (WEP-40, WEP-104)
+    // * is determined by the size of the key (5 bytes for WEP-40, 13 bytes for WEP-104).
+    // *
+    // * param ssid: Pointer to the SSID string.
+    // * param key_idx: The key index to set. Valid values are 0-3.
+    // * param key: Key input buffer.
+    // */
+    // int begin(const char* ssid, uint8_t key_idx, const char* key);
 
-        void end(void);
+    void end(void);
 
-        /* Connect as Access Point with  a standard passphrase */
-        uint8_t beginAP(const char *ssid);
-        uint8_t beginAP(const char *ssid, uint8_t channel);
-        uint8_t beginAP(const char *ssid, const char* passphrase);
-        uint8_t beginAP(const char *ssid, const char* passphrase, uint8_t channel);
+    /* Connect as Access Point with  a standard passphrase */
+    uint8_t beginAP(const char *ssid);
+    uint8_t beginAP(const char *ssid, uint8_t channel);
+    uint8_t beginAP(const char *ssid, const char *passphrase);
+    uint8_t beginAP(const char *ssid, const char *passphrase, uint8_t channel);
 
-        /* Change IP configuration settings disabling the DHCP client
-        *
-        * param local_ip:   Static IP configuration
-        * param dns_server: IP configuration for DNS server 1
-        * param gateway:    Static gateway configuration
-        * param subnet:     Static Subnet mask
-        */
-        void config(IPAddress local_ip);
-        void config(IPAddress local_ip, IPAddress dns_server);
-        void config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway);
-        void config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
+    /*
+    * Get the interface IP address.
+    * Currently only IPv4 is supported.
+    *
+    * return: IP address value. Returns 0.0.0.0 in case of error.
+    */
+    IPAddress localIP();
 
-        /*
-        * Get the interface IP address.
-        * Currently only IPv4 is supported.
-        *
-        * return: IP address value. Returns 0.0.0.0 in case of error.
-        */
-        IPAddress localIP();
+    /*
+    * Get the gateway IP address.
+    *
+    * return: gateway IP address value
+    */
+    IPAddress gatewayIP();
 
-        /*
-        * Get the gateway IP address.
-        *
-        * return: gateway IP address value
-        */
-        IPAddress gatewayIP();
+    /**
+     * Return Connection status
+     * TODO: Clean up unused or irrelevant status codes for this core.
+     *
+     *  WL_CONNECTED: assigned when connected to a WiFi network;
+     *  WL_AP_CONNECTED : assigned when a device is connected in Access Point mode;
+     *  WL_AP_LISTENING : assigned when the listening for connections in Access Point mode;
+     *  WL_NO_SHIELD: assigned when no WiFi shield is present;
+     *  WL_NO_MODULE: assigned when the communication with an integrated WiFi module fails;
+     *  WL_IDLE_STATUS: it is a temporary status assigned when WiFi.begin() is called and remains active until the number of attempts expires (resulting in WL_CONNECT_FAILED) or a connection is established (resulting in WL_CONNECTED);
+     *  WL_NO_SSID_AVAIL: assigned when no SSID are available;
+     *  WL_SCAN_COMPLETED: assigned when the scan networks is completed;
+     *  WL_CONNECT_FAILED: assigned when the connection fails for all the attempts;
+     *  WL_CONNECTION_LOST: assigned when the connection is lost;
+     *  WL_DISCONNECTED: assigned when disconnected from a network;
+     */
+    uint8_t status();
 
-        /**
-         * Return Connection status
-         * TODO: Clean up unused or irrelevant status codes for this core.
-         * 
-         *  WL_CONNECTED: assigned when connected to a WiFi network;
-         *  WL_AP_CONNECTED : assigned when a device is connected in Access Point mode;
-         *  WL_AP_LISTENING : assigned when the listening for connections in Access Point mode;
-         *  WL_NO_SHIELD: assigned when no WiFi shield is present;
-         *  WL_NO_MODULE: assigned when the communication with an integrated WiFi module fails;
-         *  WL_IDLE_STATUS: it is a temporary status assigned when WiFi.begin() is called and remains active until the number of attempts expires (resulting in WL_CONNECT_FAILED) or a connection is established (resulting in WL_CONNECTED);
-         *  WL_NO_SSID_AVAIL: assigned when no SSID are available;
-         *  WL_SCAN_COMPLETED: assigned when the scan networks is completed;
-         *  WL_CONNECT_FAILED: assigned when the connection fails for all the attempts;
-         *  WL_CONNECTION_LOST: assigned when the connection is lost;
-         *  WL_DISCONNECTED: assigned when disconnected from a network;
-         */
-        uint8_t status();
+    int hostByName(const char *aHostname, IPAddress& ip);
 
-        int hostByName(const char* aHostname, IPAddress& ip);
+    wifi_error_t getLastError();
 
-    private: 
+private:
 
-        /* Extension of cy_wcm_interface_t enums. */
+    /* Extension of cy_wcm_interface_t enums. */
         #define CY_WCM_INTERFACE_TYPE_UNKNOWN   (cy_wcm_interface_t)0xFF
 
-        cy_wcm_interface_t _mode = CY_WCM_INTERFACE_TYPE_UNKNOWN;
-        volatile wl_status_t _status = WL_IDLE_STATUS;
+    cy_wcm_interface_t _mode = CY_WCM_INTERFACE_TYPE_UNKNOWN;
+    volatile wifi_status_t _status = WIFI_STATUS_UNINITED;
+    wifi_error_t _last_error = WIFI_ERROR_NONE;
 
 
-        /* The WiFi class is implemented as singleton.
-        The constructor and destructor are private. */
-        WiFiClass();
-        ~WiFiClass();
+    /* The WiFi class is implemented as singleton.
+    The constructor and destructor are private. */
+    WiFiClass();
+    ~WiFiClass();
 
-        /* Delete copy constructor and assignment operator  */
-        WiFiClass(const WiFiClass&) = delete;
-        WiFiClass& operator = (const WiFiClass&) = delete;
+    /* Delete copy constructor and assignment operator  */
+    WiFiClass(const WiFiClass&) = delete;
+    WiFiClass& operator = (const WiFiClass&) = delete;
 
-        /**
-        * Initialize the WiFi connection manager.
-        * It support both AP and STA interfaces.
-        */
-        static cy_rslt_t wcm_init(cy_wcm_interface_t mode);
+    /**
+    * Initialize the WiFi connection manager.
+    * It support both AP and STA interfaces.
+    */
+    wifi_error_t wcm_init(cy_wcm_interface_t mode);
+    wifi_error_t wcm_assert_interface_mode(cy_wcm_interface_t mode);
+
+    static void set_sta_connect_params(cy_wcm_connect_params_t *connect_params, const char *ssid, const char *passphrase);
+    static void set_ap_params(cy_wcm_ap_config_t *ap_config, const char *ssid, const char *passphrase, uint8_t channel);
 };
 
 extern WiFiClass & WiFi;

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -10,11 +10,7 @@
 #include "cy_wcm.h"
 
 /**
-<<<<<<< HEAD
- * TODOs:
-=======
  * TODO: 
->>>>>>> 391752a (libraries/WiFi/src/WiFi: Added gatewayIP() function.)
  *  - Adapt the enum list conveniently. Do we need to keep all?
  *  - Move it to some header file?
 */
@@ -35,103 +31,104 @@ typedef enum {
 
 class WiFiClass {
 
-public:
+    public:
 
-    /* Return the WiFi class singleton */
-    static WiFiClass & get_instance();
+        /* Return the WiFi class singleton */
+        static WiFiClass & get_instance();
 
-    /* Start Wifi connection for OPEN networks
-    *
-    * param ssid: Pointer to the SSID string.
-    */
-    int begin(const char *ssid);
-
-    /* Start WiFi connection with passphrase
-    * the most secure supported mode will be automatically selected
-    *
-    * param ssid: Pointer to the SSID string.
-    * param passphrase: Passphrase. Valid characters in a passphrase
-    *        must be between ASCII 32-126 (decimal).
-    */
-    int begin(const char *ssid, const char *passphrase);
-
-    /* WEP is not supported by WCM class as considered an insecure encryption. */
-
-    // /* Start WiFi connection with WEP encryption.
-    // * Configure a key into the device. The key type (WEP-40, WEP-104)
-    // * is determined by the size of the key (5 bytes for WEP-40, 13 bytes for WEP-104).
-    // *
-    // * param ssid: Pointer to the SSID string.
-    // * param key_idx: The key index to set. Valid values are 0-3.
-    // * param key: Key input buffer.
-    // */
-    // int begin(const char* ssid, uint8_t key_idx, const char* key);
-
-    void end(void);
-
-
-    /* Connect as Access Point with  a standard passphrase */
-    uint8_t beginAP(const char *ssid);
-    uint8_t beginAP(const char *ssid, uint8_t channel);
-    uint8_t beginAP(const char *ssid, const char *passphrase);
-    uint8_t beginAP(const char *ssid, const char *passphrase, uint8_t channel);
-
-    /*
-    * Get the interface IP address.
-    * Currently only IPv4 is supported.
-    *
-    * return: IP address value. Returns 0.0.0.0 in case of error.
-    */
-    IPAddress localIP();
-
-    /*
-    * Get the gateway IP address.
-    *
-    * return: gateway IP address value
-    */
-    IPAddress gatewayIP();
-
-    /**
-        * Return Connection status
-        * TODO: Clean up unused or irrelevant status codes for this core.
-        * 
-        *  WL_CONNECTED: assigned when connected to a WiFi network;
-        *  WL_AP_CONNECTED : assigned when a device is connected in Access Point mode;
-        *  WL_AP_LISTENING : assigned when the listening for connections in Access Point mode;
-        *  WL_NO_SHIELD: assigned when no WiFi shield is present;
-        *  WL_NO_MODULE: assigned when the communication with an integrated WiFi module fails;
-        *  WL_IDLE_STATUS: it is a temporary status assigned when WiFi.begin() is called and remains active until the number of attempts expires (resulting in WL_CONNECT_FAILED) or a connection is established (resulting in WL_CONNECTED);
-        *  WL_NO_SSID_AVAIL: assigned when no SSID are available;
-        *  WL_SCAN_COMPLETED: assigned when the scan networks is completed;
-        *  WL_CONNECT_FAILED: assigned when the connection fails for all the attempts;
-        *  WL_CONNECTION_LOST: assigned when the connection is lost;
-        *  WL_DISCONNECTED: assigned when disconnected from a network;
+        /* Start Wifi connection for OPEN networks
+        *
+        * param ssid: Pointer to the SSID string.
         */
-    uint8_t status();
+        int begin(const char *ssid);
 
-private:
+        /* Start WiFi connection with passphrase
+        * the most secure supported mode will be automatically selected
+        *
+        * param ssid: Pointer to the SSID string.
+        * param passphrase: Passphrase. Valid characters in a passphrase
+        *        must be between ASCII 32-126 (decimal).
+        */
+        int begin(const char *ssid, const char *passphrase);
 
-    /* Extension of cy_wcm_interface_t enums. */
-    #define CY_WCM_INTERFACE_TYPE_UNKNOWN   (cy_wcm_interface_t)0xFF
+        /* WEP is not supported by WCM class as considered an insecure encryption. */
 
-    cy_wcm_interface_t _mode = CY_WCM_INTERFACE_TYPE_UNKNOWN;
-    volatile wl_status_t _status = WL_IDLE_STATUS;
+        // /* Start WiFi connection with WEP encryption.
+        // * Configure a key into the device. The key type (WEP-40, WEP-104)
+        // * is determined by the size of the key (5 bytes for WEP-40, 13 bytes for WEP-104).
+        // *
+        // * param ssid: Pointer to the SSID string.
+        // * param key_idx: The key index to set. Valid values are 0-3.
+        // * param key: Key input buffer.
+        // */
+        // int begin(const char* ssid, uint8_t key_idx, const char* key);
+
+        void end(void);
+
+        /* Connect as Access Point with  a standard passphrase */
+        uint8_t beginAP(const char *ssid);
+        uint8_t beginAP(const char *ssid, uint8_t channel);
+        uint8_t beginAP(const char *ssid, const char* passphrase);
+        uint8_t beginAP(const char *ssid, const char* passphrase, uint8_t channel);
+
+        /*
+        * Get the interface IP address.
+        * Currently only IPv4 is supported.
+        *
+        * return: IP address value. Returns 0.0.0.0 in case of error.
+        */
+        IPAddress localIP();
+
+        /*
+        * Get the gateway IP address.
+        *
+        * return: gateway IP address value
+        */
+        IPAddress gatewayIP();
+
+        /**
+         * Return Connection status
+         * TODO: Clean up unused or irrelevant status codes for this core.
+         * 
+         *  WL_CONNECTED: assigned when connected to a WiFi network;
+         *  WL_AP_CONNECTED : assigned when a device is connected in Access Point mode;
+         *  WL_AP_LISTENING : assigned when the listening for connections in Access Point mode;
+         *  WL_NO_SHIELD: assigned when no WiFi shield is present;
+         *  WL_NO_MODULE: assigned when the communication with an integrated WiFi module fails;
+         *  WL_IDLE_STATUS: it is a temporary status assigned when WiFi.begin() is called and remains active until the number of attempts expires (resulting in WL_CONNECT_FAILED) or a connection is established (resulting in WL_CONNECTED);
+         *  WL_NO_SSID_AVAIL: assigned when no SSID are available;
+         *  WL_SCAN_COMPLETED: assigned when the scan networks is completed;
+         *  WL_CONNECT_FAILED: assigned when the connection fails for all the attempts;
+         *  WL_CONNECTION_LOST: assigned when the connection is lost;
+         *  WL_DISCONNECTED: assigned when disconnected from a network;
+         */
+        uint8_t status();
+
+        int hostByName(const char* aHostname, IPAddress& aResult);
+
+    private: 
+
+        /* Extension of cy_wcm_interface_t enums. */
+        #define CY_WCM_INTERFACE_TYPE_UNKNOWN   (cy_wcm_interface_t)0xFF
+
+        cy_wcm_interface_t _mode = CY_WCM_INTERFACE_TYPE_UNKNOWN;
+        volatile wl_status_t _status = WL_IDLE_STATUS;
 
 
-    /* The WiFi class is implemented as singleton.
-       The constructor and destructor are private. */
-    WiFiClass();
-    ~WiFiClass();
+        /* The WiFi class is implemented as singleton.
+        The constructor and destructor are private. */
+        WiFiClass();
+        ~WiFiClass();
 
-    /* Delete copy constructor and assignment operator  */
-    WiFiClass(const WiFiClass&) = delete;
-    WiFiClass& operator = (const WiFiClass&) = delete;
+        /* Delete copy constructor and assignment operator  */
+        WiFiClass(const WiFiClass&) = delete;
+        WiFiClass& operator = (const WiFiClass&) = delete;
 
-    /**
-     * Initialize the WiFi connection manager.
-     * It support both AP and STA interfaces.
-     */
-    static cy_rslt_t wcm_init(cy_wcm_interface_t mode);
+        /**
+        * Initialize the WiFi connection manager.
+        * It support both AP and STA interfaces.
+        */
+        static cy_rslt_t wcm_init(cy_wcm_interface_t mode);
 };
 
 extern WiFiClass & WiFi;

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -71,6 +71,18 @@ class WiFiClass {
         uint8_t beginAP(const char *ssid, const char* passphrase);
         uint8_t beginAP(const char *ssid, const char* passphrase, uint8_t channel);
 
+        /* Change IP configuration settings disabling the DHCP client
+        *
+        * param local_ip:   Static IP configuration
+        * param dns_server: IP configuration for DNS server 1
+        * param gateway:    Static gateway configuration
+        * param subnet:     Static Subnet mask
+        */
+        void config(IPAddress local_ip);
+        void config(IPAddress local_ip, IPAddress dns_server);
+        void config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway);
+        void config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
+
         /*
         * Get the interface IP address.
         * Currently only IPv4 is supported.

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -16,8 +16,8 @@ socket(std::make_shared<Socket>()) {
 int WiFiClient::connect(IPAddress ip, uint16_t port) {
     socket->begin();
     
-    socket->set_receive_opt_callback(receiveCallback, this); 
-    socket->set_disconnect_opt_callback(disconnectionCallback, this);
+    socket->setReceiveOptCallback(receiveCallback, this); 
+    socket->setDisconnectOptCallback(disconnectionCallback, this);
 
     return socket->connect(ip, port);
 }
@@ -25,8 +25,8 @@ int WiFiClient::connect(IPAddress ip, uint16_t port) {
 int WiFiClient::connect(const char *host, uint16_t port) {
     socket->begin();
     
-    socket->set_receive_opt_callback(receiveCallback, this); 
-    socket->set_disconnect_opt_callback(disconnectionCallback, this);
+    socket->setReceiveOptCallback(receiveCallback, this); 
+    socket->setDisconnectOptCallback(disconnectionCallback, this);
 
     return socket->connect(host, port);
 }

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -11,10 +11,10 @@ WiFiServer::WiFiServer(){
 void WiFiServer::begin(uint16_t port) {
     socket.begin();
     
-    socket.set_timeout(SERVER_RECV_TIMEOUT_MS);
-    socket.set_connect_opt_callback(connectionCallback, this);
-    socket.set_receive_opt_callback(receiveCallback, this);
-    socket.set_disconnect_opt_callback(disconnectionCallback, this);
+    socket.setTimeout(SERVER_RECV_TIMEOUT_MS);
+    socket.setConnectOptCallback(connectionCallback, this);
+    socket.setReceiveOptCallback(receiveCallback, this);
+    socket.setDisconnectOptCallback(disconnectionCallback, this);
 
     socket.bind(port);
     socket.listen(SERVER_MAX_CLIENTS);
@@ -118,7 +118,7 @@ cy_rslt_t WiFiServer::connectionCallback(cy_socket_t socket_handle, void *arg) {
 
     if(!server->socket.accept(*(new_client.socket))) {
         server->connected_clients.pop_back();
-        return server->socket.get_last_error();
+        return server->socket.getLastError();
     }
 
     return CY_RSLT_SUCCESS;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Completion of `WiFiClass`:
* Added functions `gatewayIP()`, `hostByName()`.
* Added wifi_status_t enum to track the WiFi instance state machine. 
  - That will be used to control the validity of calls to certain functions depending on the status and the mode of the instance (station or access point).
  - This will reuse some of the status used by official core WiFi libraries to maintain compatibility accross cores.

Other changes:
Renaming of public API functions in Socket to maintain the Arduino convention.