### PR TITLE
Make docs build workflow reusable.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,13 +11,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - name: Install Python packages
-      run: pip install -r docs/requirements.txt
-    - name: Build docs
-      run: make -C docs/ html
+  makers-devops:
+    uses: Infineon/makers-devops/.github/workflows/docs_build.yml@main


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
This replaces the local workflow for build checking docs by a reusable workflow from makers-devops.

Merge Checklist
- [x] Merge https://github.com/Infineon/makers-devops/pull/19
- [x] Replace `@feature/docs-build-check` by `@main` here:
https://github.com/Infineon/arduino-core-psoc6/blob/643fc83415729b35bbd94934218e256f6a61bf03/.github/workflows/docs.yml#L15

Related Issue
Solving a not existing problem :)

Context
Once adapted in this repository, this will be rolled out to all other repos using Sphinx and Make for docs.

### Or, as Copilot would say:
(testing this new Copilot PR summary feature)

This pull request modifies the `.github/workflows/docs.yml` file to streamline the documentation build process by reusing an existing workflow. The most important change is the replacement of the existing job definition with a call to a shared workflow.

Workflow improvements:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL14-R15): Replaced the `build` job with a `call-workflow` job that uses the `docs_build.yml` workflow from the `makers-devops` repository. This change simplifies the maintenance of the documentation build process by centralizing it in a shared workflow.