### PR TITLE
Core api no rename for win

### DIFF
--- a/libraries/WiFi/examples/WiFiPing/WiFiPing.ino
+++ b/libraries/WiFi/examples/WiFiPing/WiFiPing.ino
@@ -16,7 +16,6 @@
 
 
 #include <WiFi.h>
-#include <IPAddress.h>
 #include "secrets.h" 
  
 /* Add the SSID name and PASSWORD to the secrets.h file */

--- a/libraries/WiFi/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/libraries/WiFi/examples/WiFiWebClient/WiFiWebClient.ino
@@ -22,7 +22,6 @@
 
 
 #include <WiFi.h>
-#include <IPAddress.h>
 #include "secrets.h" 
  
 /* Add the SSID name and PASSWORD to the secrets.h file */

--- a/libraries/WiFi/src/SecSocket.h
+++ b/libraries/WiFi/src/SecSocket.h
@@ -2,8 +2,8 @@
 #define CY_SECURE_SOCKET_H
 
 #include "cy_secure_sockets.h"
-#include "IPAddress.h"
-#include "RingBuffer.h"
+#include "api/IPAddress.h"
+#include "api/RingBuffer.h"
 
 typedef enum {
     SOCKET_STATUS_UNINITED = 0,

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#include "IPAddress.h"
+#include "api/IPAddress.h"
 #include "WiFiClient.h"
 #include "WiFiServer.h"
 

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -4,8 +4,8 @@
 
 #include <memory>
 #include <SecSocket.h>
-#include "Client.h"
-#include "Print.h"
+#include "api/Client.h"
+#include "api/Print.h"
 
 class WiFiClient: public arduino::Client {
 

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <WiFiClient.h>
 #include <SecSocket.h>
-#include "Server.h"
+#include "api/Server.h"
 
 class WiFiServer: public arduino::Server {
 

--- a/platform.txt
+++ b/platform.txt
@@ -34,8 +34,7 @@ compiler.define=-DARDUINO=
 compiler.arduino_core.path={runtime.platform.path}/cores/psoc6/api
 compiler.arduino_core_dep.path={compiler.arduino_core.path}/deprecated
 compiler.arduino_core_dep_avr.path={compiler.arduino_core.path}/deprecated-avr-comp/avr
-compiler.arduino_core_api.path= "-I{compiler.arduino_core_dep_avr.path}" "-I{compiler.arduino_core_dep.path}"  "-I{compiler.arduino_core.path}" 
-
+compiler.arduino_core_api.path= "-I{compiler.arduino_core_dep_avr.path}" "-I{compiler.arduino_core_dep.path}"
 
 # GCC related definitions
 # Some flags might not be required : -mtune={build.mcu}

--- a/tools/dev-setup.cmd
+++ b/tools/dev-setup.cmd
@@ -19,21 +19,4 @@ set "core_api_submodule_dir=%cd%\..\extras\arduino-core-api"
 
 xcopy /e /i /y "%core_api_submodule_dir%\api" "%cores_psoc6_dir%\api"
 
-
-REM Function to replace String.h with WString.h in Arduino core APIs
-:replace_string_h_with_wstring_h
-
-REM This statements replace String.h with WString.h in Arduino core APIs
-REM to avoid the issues with case insensitivity in windows.
-REM Issue can be followed here: https://github.com/arduino/ArduinoCore-API/issues/37
-REM Find and rename String.h to WString.h
-for /r "%cores_psoc6_dir%\api" %%f in (String.h) do (
-    rename "%%f" WString.h
-)
-
-REM Update include statements to reflect the new name
-for /r "%cores_psoc6_dir%\api" %%f in (*.h *.cpp) do (
-    powershell -Command "(Get-Content -Path '%%f') -replace '#include \"String.h\"', '#include \"WString.h\"' | Set-Content -Path '%%f'"
-)
-
 exit /b 0

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -18,19 +18,6 @@ function core_api_setup {
     cp -r ${core_api_submodule_dir}/api ${cores_psoc6_dir}/api
 }
 
-function replace_string_h_with_wstring_h {
-    # This function replaces String.h with WString.h in Arduino core APIs
-    # to avoid the issues with case insensitivity in windows.
-    # Issue can be followed here: https://github.com/arduino/ArduinoCore-API/issues/37
-    echo "Replacing String_h with WString_h in Arduino core APIs..."
-
-    # Find and rename String.h to WString.h
-    find ${cores_psoc6_dir}/api -type f -name 'String.h' -execdir mv {} WString.h \;
-
-    # Find and update include statements in C++ source files
-    find ${cores_psoc6_dir}/api -type f \( -name '*.cpp' -o -name '*.h' \) -exec sed -i 's/#include "String.h"/#include "WString.h"/g' {} \;
-}
-
 function bsps_setup {
     bsps_dir="${PWD}/../extras/mtb-integration/bsps"
     variants_dir="${PWD}/../variants"
@@ -58,6 +45,5 @@ if [ $# -gt 0 ]; then
 else
     git_submodule_setup
     core_api_setup
-    replace_string_h_with_wstring_h
     # bsps_setup #TODO: Remove this after discussion on how to include MTB sources (symlink or copy)
 fi


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Removed renaming of api files. This change makes the handling of the Arduino-CoreAPI simpler and easier to maintain.
As suggested by Arduino code owners: https://github.com/arduino/ArduinoCore-API/issues/37#issuecomment-2718229952