### PR TITLE
cores/psoc6/Uart: Fixes on tx overflow and improvements

### DIFF
--- a/cores/psoc6/Arduino.h
+++ b/cores/psoc6/Arduino.h
@@ -77,13 +77,13 @@ extern "C" {
 // ARM toolchain doesn't provide itoa etc, provide them
 #include "api/itoa.h"
 
+#include "pins_arduino.h"
+
 #ifdef __cplusplus
 #include "Uart.h"
 #endif
 
 #define Serial _UART1_
 #define Serial1 _UART2_
-
-#include "pins_arduino.h"
 
 #endif // Arduino_h

--- a/cores/psoc6/Uart.cpp
+++ b/cores/psoc6/Uart.cpp
@@ -142,3 +142,11 @@ void Uart::IrqHandler() {
         }
     }
 }
+
+#if SERIAL_HOWMANY > 0
+Uart _UART1_(UART1_TX_PIN, UART1_RX_PIN, NC, NC);
+#endif
+
+#if SERIAL_HOWMANY > 1
+Uart _UART2_(UART2_TX_PIN, UART2_RX_PIN, NC, NC);
+#endif

--- a/cores/psoc6/Uart.cpp
+++ b/cores/psoc6/Uart.cpp
@@ -1,13 +1,6 @@
 #include "Uart.h"
 #include "cybsp.h"
 
-
-#ifdef Serial
-#undef Serial
-#endif
-
-Uart *Uart::g_uarts[MAX_UARTS] = {nullptr};
-
 Uart::Uart(cyhal_gpio_t tx, cyhal_gpio_t rx, cyhal_gpio_t cts, cyhal_gpio_t rts) : tx_pin(tx), rx_pin(rx), cts_pin(cts), rts_pin(rts) {
 }
 
@@ -70,8 +63,7 @@ int Uart::available(void) {
 }
 
 int Uart::availableForWrite() {
-    uint32_t ret = cyhal_uart_writable(&uart_obj);
-    return ret;
+    return cyhal_uart_writable(&uart_obj);
 }
 
 void Uart::end() {

--- a/cores/psoc6/Uart.cpp
+++ b/cores/psoc6/Uart.cpp
@@ -2,8 +2,18 @@
 #include "Uart.h"
 #include "cyhal_gpio.h"
 
+#define uart_assert(cy_ret, ret_code)   if (cy_ret != CY_RSLT_SUCCESS) { \
+            last_error = ret_code; \
+            return; \
+}
+
+
 Uart::Uart(pin_size_t tx, pin_size_t rx, pin_size_t cts, pin_size_t rts) : tx_pin(tx), rx_pin(rx), cts_pin(cts), rts_pin(rts) {
 
+}
+
+Uart::~Uart() {
+    end();
 }
 
 void Uart::begin(unsigned long baud) {
@@ -55,14 +65,15 @@ void Uart::begin(unsigned long baud, uint16_t config) {
     cyhal_gpio_t cy_cts_pin = (cts_pin == NC) ? NC : mapping_gpio_pin[cts_pin];
     cyhal_gpio_t cy_rts_pin = (rts_pin == NC) ? NC : mapping_gpio_pin[rts_pin];
 
-    /**
-     * TODO: Error handling of cyhal return is not implemented.
-     */
-    cyhal_uart_init(&uart_obj, mapping_gpio_pin[tx_pin], mapping_gpio_pin[rx_pin], cy_cts_pin, cy_rts_pin, NULL, &uart_config);
-    cyhal_uart_set_baud(&uart_obj, baud, &actualbaud);
+    cy_rslt_t ret = cyhal_uart_init(&uart_obj, mapping_gpio_pin[tx_pin], mapping_gpio_pin[rx_pin], cy_cts_pin, cy_rts_pin, NULL, &uart_config);
+    uart_assert(ret, UART_ERROR_INIT_FAILED);
+    ret = cyhal_uart_set_baud(&uart_obj, baud, &actualbaud);
+    uart_assert(ret, UART_ERROR_SET_BAUD_FAILED);
 
     cyhal_uart_register_callback(&uart_obj, Uart::uart_event_handler, this);
     cyhal_uart_enable_event(&uart_obj, CYHAL_UART_IRQ_RX_NOT_EMPTY, 7, true);
+
+    serial_ready = true;
 }
 
 int Uart::available(void) {
@@ -77,6 +88,7 @@ void Uart::end() {
     cyhal_uart_clear(&uart_obj);
     cyhal_uart_free(&uart_obj);
     rx_buffer.clear();
+    serial_ready = false;
 }
 
 void Uart::flush() {
@@ -132,6 +144,14 @@ size_t Uart::write(const uint8_t *buffer, size_t size) {
     } while (left_to_write > 0 && (millis() - time_start_ms) < timeout_ms);
 
     return size - left_to_write;
+}
+
+Uart::operator bool() {
+    return serial_ready;
+}
+
+uart_error_t Uart::getLastError() {
+    return last_error;
 }
 
 void Uart::uart_event_handler(void *handler_arg, cyhal_uart_event_t event) {

--- a/cores/psoc6/Uart.h
+++ b/cores/psoc6/Uart.h
@@ -2,6 +2,7 @@
 
 #include "Arduino.h"
 #include "api/HardwareSerial.h"
+#include "api/RingBuffer.h"
 #include "cyhal_uart.h"
 #include "cyhal_gpio.h"
 
@@ -42,6 +43,8 @@ public:
 
 
 private:
+
+    static constexpr size_t BUFFER_LENGTH = 512;
     cyhal_gpio_t tx_pin;
     cyhal_gpio_t rx_pin;
     cyhal_gpio_t cts_pin;
@@ -54,11 +57,7 @@ private:
     uint32_t extractParity(uint16_t config);
     uint32_t extractDataBits(uint16_t config);
 
-    // Software buffer
-    static const int bufferSize = 512;
-    uint8_t buffer[bufferSize];
-    volatile int bufferHead;
-    volatile int bufferTail;
+    arduino::RingBufferN < BUFFER_LENGTH > rx_buffer;
 
     void IrqHandler();
 };

--- a/cores/psoc6/Uart.h
+++ b/cores/psoc6/Uart.h
@@ -6,12 +6,10 @@
 #include "cyhal_uart.h"
 #include "cyhal_gpio.h"
 
-#define MAX_UARTS    10
-
 class Uart: public arduino::HardwareSerial
 {
 public:
-    static Uart * g_uarts[MAX_UARTS];
+
     Uart(cyhal_gpio_t tx, cyhal_gpio_t rx, cyhal_gpio_t cts, cyhal_gpio_t rts);
     void begin(unsigned long baud);
     void begin(unsigned long baud, uint16_t config);
@@ -23,18 +21,7 @@ public:
     void flush(void);
     virtual size_t write(uint8_t c);
     virtual size_t write(const uint8_t *buffer, size_t size);
-    inline size_t write(unsigned long n) {
-        return write((uint8_t)n);
-    }
-    inline size_t write(long n) {
-        return write((uint8_t)n);
-    }
-    inline size_t write(unsigned int n) {
-        return write((uint8_t)n);
-    }
-    inline size_t write(int n) {
-        return write((uint8_t)n);
-    }
+
     using Print::write;
     operator bool() {
         return true;
@@ -44,7 +31,6 @@ public:
 
 private:
 
-    static constexpr size_t BUFFER_LENGTH = 512;
     cyhal_gpio_t tx_pin;
     cyhal_gpio_t rx_pin;
     cyhal_gpio_t cts_pin;
@@ -52,11 +38,12 @@ private:
     cyhal_uart_t uart_obj;
     cyhal_uart_cfg_t uart_config;
     uint32_t actualbaud;
-    cy_rslt_t result;
+
     uint32_t extractStopBit(uint16_t config);
     uint32_t extractParity(uint16_t config);
     uint32_t extractDataBits(uint16_t config);
 
+    static constexpr size_t BUFFER_LENGTH = 512;
     arduino::RingBufferN < BUFFER_LENGTH > rx_buffer;
 
     void IrqHandler();

--- a/cores/psoc6/Uart.h
+++ b/cores/psoc6/Uart.h
@@ -1,16 +1,14 @@
 #pragma once
 
-#include "Arduino.h"
 #include "api/HardwareSerial.h"
 #include "api/RingBuffer.h"
 #include "cyhal_uart.h"
-#include "cyhal_gpio.h"
 
 class Uart: public arduino::HardwareSerial
 {
 public:
 
-    Uart(cyhal_gpio_t tx, cyhal_gpio_t rx, cyhal_gpio_t cts, cyhal_gpio_t rts);
+    Uart(pin_size_t tx, pin_size_t rx, pin_size_t cts = NC, pin_size_t rts = NC);
     void begin(unsigned long baud);
     void begin(unsigned long baud, uint16_t config);
     void end();
@@ -31,10 +29,10 @@ public:
 
 private:
 
-    cyhal_gpio_t tx_pin;
-    cyhal_gpio_t rx_pin;
-    cyhal_gpio_t cts_pin;
-    cyhal_gpio_t rts_pin;
+    pin_size_t tx_pin;
+    pin_size_t rx_pin;
+    pin_size_t cts_pin;
+    pin_size_t rts_pin;
     cyhal_uart_t uart_obj;
     cyhal_uart_cfg_t uart_config;
     uint32_t actualbaud;
@@ -49,5 +47,10 @@ private:
     void IrqHandler();
 };
 
+#if (SERIAL_HOWMANY > 0)
 extern Uart _UART1_;
+#endif
+
+#if (SERIAL_HOWMANY > 1)
 extern Uart _UART2_;
+#endif

--- a/cores/psoc6/Uart.h
+++ b/cores/psoc6/Uart.h
@@ -16,7 +16,7 @@ public:
     void begin(unsigned long baud, uint16_t config);
     void end();
     int available(void);
-    int availableForWrite();
+    virtual int availableForWrite();
     int peek(void);
     int read(void);
     void flush(void);
@@ -34,7 +34,7 @@ public:
     inline size_t write(int n) {
         return write((uint8_t)n);
     }
-    using Print::write;     // pull in write(str) and write(buf, size) from Print
+    using Print::write;
     operator bool() {
         return true;
     }
@@ -55,10 +55,11 @@ private:
     uint32_t extractDataBits(uint16_t config);
 
     // Software buffer
-    static const int bufferSize = 128;
+    static const int bufferSize = 512;
     uint8_t buffer[bufferSize];
     volatile int bufferHead;
     volatile int bufferTail;
+
     void IrqHandler();
 };
 

--- a/cores/psoc6/Uart0.cpp
+++ b/cores/psoc6/Uart0.cpp
@@ -1,5 +1,0 @@
-#include "Uart.h"
-
-#if SERIAL_HOWMANY > 0
-Uart _UART1_(UART1_TX_PIN, UART1_RX_PIN, NC, NC);
-#endif

--- a/cores/psoc6/Uart1.cpp
+++ b/cores/psoc6/Uart1.cpp
@@ -1,5 +1,0 @@
-#include "Uart.h"
-
-#if SERIAL_HOWMANY > 1
-Uart _UART2_(UART2_TX_PIN, UART2_RX_PIN, NC, NC);
-#endif

--- a/tests/cy8ckit-062s2-ai-hil-test-table.md
+++ b/tests/cy8ckit-062s2-ai-hil-test-table.md
@@ -4,6 +4,8 @@
 |---------------|---------------|---------------|--------------------------------|
 | UART          | P10.1         | P10.0         | UART TX to RX                  |
 |               | P10.0         | P10.1         | UART RX to TX                  |
+|               | P9.4          | P9.4          | IO synch signal                |
+|               | GND           | GND           | Common Ground                  |
 |               |               |               |                                |
 | Wire 1        | P0.2          | P0.2          | I2C SCL to SCL (with pullup)   |
 |               | P0.3          | P0.3          | I2C SDA to SDA (with pullup)   |
@@ -13,6 +15,7 @@
 |               | P9_1          | P9_1          | MISO to MISO                   |
 |               | P9_2          | P9_2          | SCLK to SCLK                   |
 |               | P9_3 (IO_0)   | P9_3 (IO_0)   | GPIO pin as SPI SSEL           |
+|               | P9.4          | P9.4          | IO synch signal                |
 |               | GND           | GND           | Common Ground                  |
 |               |               |               |                                |
 

--- a/variants/CY8CKIT-062S2-AI/pins_arduino.h
+++ b/variants/CY8CKIT-062S2-AI/pins_arduino.h
@@ -31,10 +31,14 @@
 /****** UART CORE DEFINES ******/
 
 #define SERIAL_HOWMANY		2
-#define UART1_TX_PIN      CYBSP_DEBUG_UART_TX
-#define UART1_RX_PIN      CYBSP_DEBUG_UART_RX
-#define UART2_TX_PIN      P10_1
-#define UART2_RX_PIN      P10_0
+#define UART1_TX_PIN      32  // UART_TX P5_1
+#define UART1_RX_PIN      31  // UART_RX P5_0
+#define UART1_CTS_PIN     NC  // NOT CONNECTED
+#define UART1_RTS_PIN     NC  // NOT CONNECTED
+#define UART2_TX_PIN      10  // UART_TX P10_1
+#define UART2_RX_PIN      11  // UART_RX P10_0
+#define UART2_CTS_PIN     NC  // NOT CONNECTED
+#define UART2_RTS_PIN     NC  // NOT CONNECTED
 
 #define I2C_HOWMANY    2
 #define I2C1_SDA_PIN    CYBSP_I2C_SDA
@@ -109,7 +113,12 @@ const cyhal_gpio_t mapping_gpio_pin[] = {
     /* 27  */ P8_4,// UART_RX / I2C-SCL / IO /PWM                     
     /* 28  */ P8_5,// UART_TX / I2C-SDA / IO /PWM                     
     /* 29  */ P12_4,// SDHC_CMD / IO /PWM                             
-    /* 30  */ P12_5,// SDHC_CLK / IO /PWM                             
+    /* 30  */ P12_5,// SDHC_CLK / IO /PWM
+
+    // Debugger Serial UART pins (not available on connector) 
+    
+    /* 31  */ P5_0, // DEBUG_UART_RX 
+    /* 32  */ P5_1, // DEBUG_UART_TX 
 };
 
 const uint8_t GPIO_PIN_COUNT = (sizeof(mapping_gpio_pin) / sizeof(mapping_gpio_pin[0])) - 1;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

This pull request refactors the UART implementation for the PSoC6 platform, improving code maintainability, flexibility, and functionality. Key changes include the introduction of hardware flow control, a new ring buffer for RX data, and enhanced error handling. Additionally, the UART pin definitions were updated for better clarity and usability.

### UART Refactoring:

* Replaced software buffer with `RingBuffer` for RX data, improving performance and simplifying buffer management (`cores/psoc6/Uart.cpp`, `cores/psoc6/Uart.h`). [[1]](diffhunk://#diff-691236c3cdcd271ffed3146ac66ca548dfe961110a31c881843019123057d2d6R1-R16) [[2]](diffhunk://#diff-691236c3cdcd271ffed3146ac66ca548dfe961110a31c881843019123057d2d6L58-R154) [[3]](diffhunk://#diff-691236c3cdcd271ffed3146ac66ca548dfe961110a31c881843019123057d2d6L141-R179) [[4]](diffhunk://#diff-09ffad27c237ff8b5e6dad087f1360b20301a4bdfc86c36041c50dd1376b29cbL3-R62)
* Added hardware flow control support by introducing CTS and RTS pins as optional parameters in the `Uart` constructor (`cores/psoc6/Uart.cpp`, `cores/psoc6/Uart.h`). [[1]](diffhunk://#diff-691236c3cdcd271ffed3146ac66ca548dfe961110a31c881843019123057d2d6R1-R16) [[2]](diffhunk://#diff-09ffad27c237ff8b5e6dad087f1360b20301a4bdfc86c36041c50dd1376b29cbL3-R62)
* Improved error handling with a new `uart_error_t` enum and `getLastError` method to track initialization and baud rate configuration issues (`cores/psoc6/Uart.cpp`, `cores/psoc6/Uart.h`). [[1]](diffhunk://#diff-691236c3cdcd271ffed3146ac66ca548dfe961110a31c881843019123057d2d6R1-R16) [[2]](diffhunk://#diff-09ffad27c237ff8b5e6dad087f1360b20301a4bdfc86c36041c50dd1376b29cbL3-R62)

### Code Cleanup and Simplification:

* Removed legacy software buffer code and unused methods, such as overloaded `write` methods for various integer types (`cores/psoc6/Uart.cpp`, `cores/psoc6/Uart.h`). [[1]](diffhunk://#diff-691236c3cdcd271ffed3146ac66ca548dfe961110a31c881843019123057d2d6R1-R16) [[2]](diffhunk://#diff-09ffad27c237ff8b5e6dad087f1360b20301a4bdfc86c36041c50dd1376b29cbL3-R62)
* Consolidated UART initialization by eliminating redundant files `Uart0.cpp` and `Uart1.cpp` and moving instance definitions into `Uart.cpp` (`cores/psoc6/Uart0.cpp`, `cores/psoc6/Uart1.cpp`, `cores/psoc6/Uart.cpp`). [[1]](diffhunk://#diff-3cae94f98963fbe8dc6be29f3f0b230acc52ca40f47f68e0f5766598e4fa73eeL1-L5) [[2]](diffhunk://#diff-fe7b533a9f46db219b00364e4f43d81154e6254a633b9a371c4e4951d4cc6084L1-L5) [[3]](diffhunk://#diff-691236c3cdcd271ffed3146ac66ca548dfe961110a31c881843019123057d2d6L141-R179)

### Pin Definitions Update:

* Updated UART pin mappings in `pins_arduino.h` to use logical pin numbers instead of PSoC-specific identifiers, enhancing readability and consistency (`variants/CY8CKIT-062S2-AI/pins_arduino.h`). [[1]](diffhunk://#diff-105160e20d53ca8cdc468482d74c0e6024b68cbd4a7b25825829ba17c969882fL34-R41) [[2]](diffhunk://#diff-105160e20d53ca8cdc468482d74c0e6024b68cbd4a7b25825829ba17c969882fR117-R121)

### Miscellaneous:

* Moved `#include "pins_arduino.h"` to the correct location in `Arduino.h` for proper dependency resolution (`cores/psoc6/Arduino.h`).
* Updated the Arduino core tests submodule to the latest commit (`tests/arduino-core-tests`).

### Relates tests
https://github.com/Infineon/arduino-core-tests/pull/28 