### PR TITLE
cores/psoc6/time.c : Refactored delay() and delayMicroseconds() implementation.

### DIFF
--- a/cores/psoc6/time.c
+++ b/cores/psoc6/time.c
@@ -81,13 +81,19 @@ unsigned long micros() {
 }
 
 void delay(unsigned long ms) {
-    const TickType_t xDelay = ms / portTICK_PERIOD_MS;
-    vTaskDelay(xDelay);
+    unsigned long start = millis();
+    while (millis() - start < ms) {
+        // Yield to allow other processes to run
+        yield();
+    }
 }
 
 void delayMicroseconds(unsigned int us) {
-    const TickType_t xDelay = us / (portTICK_PERIOD_MS * MILLISECONDS_PER_SECOND);
-    vTaskDelay(xDelay);
+    unsigned long start = micros();
+    while (micros() - start < us) {
+        // Yield to allow other processes to run
+        yield();
+    }
 }
 
 #ifdef __cplusplus

--- a/libraries/Wire/examples/slave_receiver/slave_receiver.ino
+++ b/libraries/Wire/examples/slave_receiver/slave_receiver.ino
@@ -24,13 +24,7 @@ void setup()
 
 void loop()
 {
-  /**
-   * This delay is preventing the slave interrupts 
-   * to be executed. Currently commented out.
-   * TODO: Conflict with RTOS delay and interrupts prio operation
-   * to be resolved.
   delay(100);
-  */
 }
 
 // function that executes whenever data is received from master

--- a/libraries/Wire/examples/slave_sender/slave_sender.ino
+++ b/libraries/Wire/examples/slave_sender/slave_sender.ino
@@ -23,13 +23,7 @@ void setup()
 
 void loop()
 {
-  /**
-   * This delay is preventing the slave interrupts 
-   * to be executed. Currently commented out.
-   * TODO: Conflict with RTOS delay and interrupts prio operation
-   * to be resolved.
   delay(100);
-  */
 }
 
 // function that executes whenever data is requested by master


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Reverted delay functions to original implementation. 
We used systick originally, then it was not working with wifi so we replaced it by vTaskDelay(). 
Then we refactored it based on the cyhal_timer, but keep the vTaskDelay() implementation. And that is blocking the interrupt triggering (we had this behavior in the Wire slave implementation). 
Now with the cyhal_timer implementation, the original millis()/micro() time difference works without any identified flaw.

Manually evaluated the following tests:
- test_digitalio_single
- test_interrupts_single
- test_uart_tx - test_uart_rx
- wifi (all)
- Wire examples (with the previously conflicting delay() introduced again)