### PR TITLE
libraries/SPI: Fix parsing of NC value.

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -17,7 +17,7 @@ void SPIClassPSOC::begin() {
     if (_is_initialized) {
         return;
     }
-    status = cyhal_spi_init(&_spi_obj, mapping_gpio_pin[_mosi_pin], mapping_gpio_pin[_miso_pin], mapping_gpio_pin[_sck_pin], mapping_gpio_pin[_ssel_pin], NULL, 8, getSpiMode(), _is_slave);
+    status = cyhal_spi_init(&_spi_obj, mapping_gpio_pin[_mosi_pin], mapping_gpio_pin[_miso_pin], mapping_gpio_pin[_sck_pin], _ssel_pin == NC ? NC : mapping_gpio_pin[_ssel_pin], NULL, 8, getSpiMode(), _is_slave);
 
     spi_assert(status);
     status = cyhal_spi_set_frequency(&_spi_obj, _settings.getClockFreq());


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
The change ensures proper handling of the `_ssel_pin` parameter when it is set to `NC` (not connected).

* [`libraries/SPI/src/SPI.cpp`](diffhunk://#diff-622bbeef9fa9d6ba8af6dc3d28e4d5171c697731b6da352e7a18c8e9fddb687eL20-R20): Modified the `cyhal_spi_init` call to pass `NC` directly for `_ssel_pin` in case no other pin name is defined, and **not** providing NC to the pin mapping function.

Related Issue
SPI chip select pin not correctly parsed in master mode, because NC has been provided to the pin mapping function.

Testing
This has been tested in the field together with the multi-half-bridge library and works fine.
Please test in your local test setups before approving.