### PR TITLE
Wifi udp begin packet

### DIFF
--- a/libraries/WiFi/src/WiFiUdp.cpp
+++ b/libraries/WiFi/src/WiFiUdp.cpp
@@ -41,15 +41,23 @@ void WiFiUDP::stop() {
 }
 
 int WiFiUDP::beginPacket(IPAddress ip, uint16_t port) {
-    return 0;
+    remote_ip = ip;
+    _port = port;
+    return 1; // Return 1 if successful
 }
 
 int WiFiUDP::beginPacket(const char *host, uint16_t port) {
+    // Resolve the hostname to an IP address
+    IPAddress ip;
+    if (socket.hostByName(host, ip)) {
+        return beginPacket(ip, port); // Call the IP-based version
+    }
+
+    // Return 0 if hostname resolution fails
     return 0;
 }
 
 int WiFiUDP::endPacket() {
-    return 0;
 }
 
 size_t WiFiUDP::write(uint8_t) {


### PR DESCRIPTION
UDP. beginPacket(IPAddress ip, uint16_t port)

UDP. beginPacket(const char *host, uint16_t port)

![begin packet](https://github.com/user-attachments/assets/6dd34c1a-4e56-4f8a-a69a-a90298c16adf)

UDP. beginPacket(IPAddress ip, uint16_t port) is added in the testcase and since hostname resolution is tested as part of WiFi class , I have not added test for that . 