### PR TITLE
libraries/WiFi: Increased socket rx buffer insufficient length.

### DIFF
--- a/libraries/WiFi/src/SecSocket.h
+++ b/libraries/WiFi/src/SecSocket.h
@@ -70,7 +70,7 @@ private:
 
     void setOptCallback(int optname, cy_socket_callback_t cback, void *arg);
 
-    static const uint16_t RX_BUFFER_SIZE = 256;
+    static const uint16_t RX_BUFFER_SIZE = 4096;
     arduino::RingBufferN < RX_BUFFER_SIZE > rx_buf;
 
     bool connect(cy_socket_sockaddr_t *addr);

--- a/libraries/WiFi/src/WiFiUdp.cpp
+++ b/libraries/WiFi/src/WiFiUdp.cpp
@@ -132,10 +132,12 @@ int WiFiUDP::read() {
 
 int WiFiUDP::read(unsigned char *buffer, size_t len) {
 
-    if (current_packet.rx_buf.available() < 1) {
+    size_t rx_available = (size_t)current_packet.rx_buf.available();
+    if (rx_available < 1) {
         return -1;
     }
-    len = len > current_packet.rx_buf.available() ? current_packet.rx_buf.available() : len;
+
+    len = len > rx_available ? rx_available : len;
     for (size_t i = 0; i < len; i++) {
         buffer[i] = current_packet.rx_buf.read_char();
     }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

* Increased socket rx buffer. It was making some applications to fail to due to overflow. 
* Fixed warning due to int to size_t implicit cast. 