### PR TITLE
Gpio reinit fix

### DIFF
--- a/cores/psoc6/Arduino.h
+++ b/cores/psoc6/Arduino.h
@@ -40,7 +40,7 @@ extern "C" {
 extern const cyhal_gpio_t mapping_gpio_pin[];
 extern const uint8_t GPIO_PIN_COUNT;
 extern bool gpio_initialized[];
-extern bool lastInitPinValue[];
+extern bool currentPinValue[];
 
 #define GPIO_INTERRUPT_PRIORITY 3 // GPIO interrupt priority
 #define digitalPinToInterrupt(p) ((p) < GPIO_PIN_COUNT ? (p) : -1)

--- a/cores/psoc6/Arduino.h
+++ b/cores/psoc6/Arduino.h
@@ -40,6 +40,7 @@ extern "C" {
 extern const cyhal_gpio_t mapping_gpio_pin[];
 extern const uint8_t GPIO_PIN_COUNT;
 extern bool gpio_initialized[];
+extern bool lastInitPinValue[];
 
 #define GPIO_INTERRUPT_PRIORITY 3 // GPIO interrupt priority
 #define digitalPinToInterrupt(p) ((p) < GPIO_PIN_COUNT ? (p) : -1)

--- a/cores/psoc6/digital_io.c
+++ b/cores/psoc6/digital_io.c
@@ -63,20 +63,16 @@ void pinMode(pin_size_t pinNumber, PinMode pinMode) {
             return; // Invalid mode
     }
 
-    // check if pinNumber is initialized before
     if (gpio_initialized[pinNumber]) {
         if (lastInitPinValue[pinNumber] != initPinValue) {
-            // If initPinValue is changing, free and re-init
             cyhal_gpio_free(mapping_gpio_pin[pinNumber]);
             gpio_initialized[pinNumber] = false;
         } else {
-            // If not changing, just reconfigure
             cyhal_gpio_configure(mapping_gpio_pin[pinNumber], direction, drive_mode);
             return;
         }
     }
 
-    // Initialize the GPIO pin with the specified direction, drive mode and set initial value
     (void)cyhal_gpio_init(mapping_gpio_pin[pinNumber], direction, drive_mode, initPinValue);
     gpio_initialized[pinNumber] = true;
     lastInitPinValue[pinNumber] = initPinValue;

--- a/cores/psoc6/digital_io.c
+++ b/cores/psoc6/digital_io.c
@@ -64,7 +64,7 @@ void pinMode(pin_size_t pinNumber, PinMode pinMode) {
     }
 
     if (gpio_initialized[pinNumber]) {
-        if (lastInitPinValue[pinNumber] != initPinValue) {
+        if (currentPinValue[pinNumber] != initPinValue) {
             cyhal_gpio_free(mapping_gpio_pin[pinNumber]);
             gpio_initialized[pinNumber] = false;
         } else {
@@ -75,15 +75,21 @@ void pinMode(pin_size_t pinNumber, PinMode pinMode) {
 
     (void)cyhal_gpio_init(mapping_gpio_pin[pinNumber], direction, drive_mode, initPinValue);
     gpio_initialized[pinNumber] = true;
-    lastInitPinValue[pinNumber] = initPinValue;
+    currentPinValue[pinNumber] = initPinValue;
 }
 
 PinStatus digitalRead(pin_size_t pinNumber) {
-    return cyhal_gpio_read(mapping_gpio_pin[pinNumber]) ? HIGH : LOW;
+    currentPinValue[pinNumber] = cyhal_gpio_read(mapping_gpio_pin[pinNumber]) ? HIGH : LOW;
+    return currentPinValue[pinNumber];
 }
 
 void digitalWrite(pin_size_t pinNumber, PinStatus status) {
     cyhal_gpio_write(mapping_gpio_pin[pinNumber], status);
+    if (status == LOW) {
+        currentPinValue[pinNumber] = false;
+    } else {
+        currentPinValue[pinNumber] = true;
+    }
 }
 
 #ifdef __cplusplus

--- a/variants/CY8CKIT-062S2-AI/pins_arduino.h
+++ b/variants/CY8CKIT-062S2-AI/pins_arduino.h
@@ -194,7 +194,7 @@ const cyhal_gpio_t mapping_gpio_pin[] = {
 const uint8_t GPIO_PIN_COUNT = (sizeof(mapping_gpio_pin) / sizeof(mapping_gpio_pin[0])) - 1;
 
 bool gpio_initialized[GPIO_PIN_COUNT] = {false};
-bool lastInitPinValue[GPIO_PIN_COUNT] = {false};
+bool currentPinValue[GPIO_PIN_COUNT] = {false};
 
 #ifdef __cplusplus
 }

--- a/variants/CY8CKIT-062S2-AI/pins_arduino.h
+++ b/variants/CY8CKIT-062S2-AI/pins_arduino.h
@@ -194,6 +194,7 @@ const cyhal_gpio_t mapping_gpio_pin[] = {
 const uint8_t GPIO_PIN_COUNT = (sizeof(mapping_gpio_pin) / sizeof(mapping_gpio_pin[0])) - 1;
 
 bool gpio_initialized[GPIO_PIN_COUNT] = {false};
+bool lastInitPinValue[GPIO_PIN_COUNT] = {false};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Since the previous way of reinitialising the pin is not always needed, I refactored the code such that now

- cyhal_gpio_free is used only when the initial pin value should be changed
- chyal_gpio_reconfigure is used when there is a reconfiguration ( change in pin direction or drive) 

Now this also helps in reducing the delay that is caused while using the onewire library

