### PR TITLE
Fix/add missing itoa ultoa

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -19,3 +19,50 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+------------------------------------------------------------------------------
+
+The sources of this repository are licensed under the MIT License, except otherwise specified.
+
+The list of directories and files that are licensed under different licenses:
+
+**GNU Lesser General Public License (LGPL) v2.1+:**
+- cores/psoc6/Arduino.h - Copyright (c) 2014 Arduino LLC
+- cores/psoc6/main.cpp - Copyright (c) 2015 Arduino LLC
+- cores/psoc6/time.c - Copyright (c) 2015 Arduino LLC
+- cores/psoc6/time.h - Copyright (c) 2015 Arduino LLC
+- cores/psoc6/interrupts.c - Copyright (c) 2015 Arduino LLC
+- cores/psoc6/digital_io.c - Copyright (c) 2015 Arduino LLC
+- cores/psoc6/yield.c - Copyright (c) 2015 Arduino LLC
+- cores/psoc6/itoa.c - Copyright (c) 2014 Arduino LLC
+- cores/psoc6/api/String.cpp - Copyright (c) 2009-10 Hernando Barragan, Copyright 2011 Paul Stoffregen
+- cores/psoc6/api/String.h - Copyright (c) 2009-10 Hernando Barragan
+- cores/psoc6/api/Stream.cpp - Copyright (c) 2008 David A. Mellis
+- cores/psoc6/api/Stream.h - Copyright (c) 2010 David A. Mellis
+- cores/psoc6/api/Binary.h - Copyright (c) 2006 David A. Mellis
+- cores/psoc6/api/Client.h - Copyright (c) 2011 Adrian McEwen
+- cores/psoc6/api/Server.h - Copyright (c) 2011 Adrian McEwen
+- cores/psoc6/api/IPAddress.h - Copyright (c) 2011 Adrian McEwen
+- cores/psoc6/api/IPAddress.cpp - Copyright (c) 2011 Adrian McEwen
+- cores/psoc6/api/WCharacter.h - Copyright (c) 2010 Hernando Barragan
+- cores/psoc6/api/deprecated-avr-comp/avr/dtostrf.h - Copyright (c) 2015 Arduino LLC
+- cores/psoc6/api/deprecated-avr-comp/avr/dtostrf.c.impl - Copyright (c) 2016 Arduino LLC
+- variants/CY8CKIT-062S2-AI/pins_arduino.h - Copyright (c) 2015 Arduino LLC
+
+**MIT License (different copyright holders):**
+- cores/psoc6/api/Udp.h - Copyright (c) 2008 Bjoern Hartmann
+- arduino-devops/ - Copyright (c) 2025 Infineon
+- extras/mtb-libs/freertos/ - Copyright (c) 2024 Infineon Technologies AG
+
+**Apache License 2.0:**
+- extras/mtb-libs/mbedtls/ - Apache 2.0 License
+- extras/mtb-libs/cy-mbedtls-acceleration/ - Apache 2.0, Copyright ARM Limited and Cypress Semiconductor Corporation
+- variants/CY8CKIT-062S2-AI/mtb-bsp/cybsp.h - Apache 2.0, Copyright Cypress Semiconductor/Infineon
+- variants/CY8CKIT-062S2-AI/mtb-bsp/cybsp.c - Apache 2.0, Copyright Cypress Semiconductor/Infineon
+
+**Proprietary/Custom Licenses:**
+- extras/mtb-libs/wpa3-external-supplicant/ - Cypress Semiconductor proprietary licensing
+- extras/mtb-libs/wifi-host-driver/ - Contains permissive binary license components
+
+**Dual Licensed (MIT/GPL v2):**
+- extras/mtb-libs/freertos/docs/api_reference_manual/html/jquery.js - jQuery library

--- a/ci-matrix-config.yml
+++ b/ci-matrix-config.yml
@@ -4,3 +4,4 @@ include:
     - extras/arduino-examples/examples/03.Analog/AnalogInOutSerial/AnalogInOutSerial.ino
     - extras/arduino-examples/examples/02.Digital/toneMultiple/toneMultiple.ino
     - extras/arduino-examples/examples/06.Sensors/Memsic2125/Memsic2125.ino
+    - extras/arduino-examples/examples/08.Strings/StringConstructors/StringConstructors.ino

--- a/cores/psoc6/itoa.c
+++ b/cores/psoc6/itoa.c
@@ -1,0 +1,119 @@
+/*
+  Copyright (c) 2014 Arduino LLC.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <api/itoa.h>
+#include <api/deprecated-avr-comp/avr/dtostrf.c.impl>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern char * itoa(int value, char *string, int radix) {
+    return ltoa(value, string, radix);
+}
+
+extern char * ltoa(long value, char *string, int radix) {
+    char tmp[33];
+    char *tp = tmp;
+    long i;
+    unsigned long v;
+    int sign;
+    char *sp;
+
+    if (string == NULL) {
+        return 0;
+    }
+
+    if (radix > 36 || radix <= 1) {
+        return 0;
+    }
+
+    sign = (radix == 10 && value < 0);
+    if (sign) {
+        v = -value;
+    } else {
+        v = (unsigned long)value;
+    }
+
+    while (v || tp == tmp) {
+        i = v % radix;
+        v = v / radix;
+        if (i < 10) {
+            *tp++ = i + '0';
+        } else {
+            *tp++ = i + 'a' - 10;
+        }
+    }
+
+    sp = string;
+
+    if (sign) {
+        *sp++ = '-';
+    }
+    while (tp > tmp) {
+        *sp++ = *--tp;
+    }
+    *sp = 0;
+
+    return string;
+}
+
+extern char * utoa(unsigned int value, char *string, int radix) {
+    return ultoa(value, string, radix);
+}
+
+extern char * ultoa(unsigned long value, char *string, int radix) {
+    char tmp[33];
+    char *tp = tmp;
+    long i;
+    unsigned long v = value;
+    char *sp;
+
+    if (string == NULL) {
+        return 0;
+    }
+
+    if (radix > 36 || radix <= 1) {
+        return 0;
+    }
+
+    while (v || tp == tmp) {
+        i = v % radix;
+        v = v / radix;
+        if (i < 10) {
+            *tp++ = i + '0';
+        } else {
+            *tp++ = i + 'a' - 10;
+        }
+    }
+
+    sp = string;
+
+
+    while (tp > tmp) {
+        *sp++ = *--tp;
+    }
+    *sp = 0;
+
+    return string;
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

* Added missing integer to char functions (not provided by the standard library). The file is taken from the renesas Arduino core.
* Added String() constructor examples.
* List dir or files with other than MIT license.