### PR TITLE
Integrate cortex debugger

### DIFF
--- a/docs/debugging-instructions.rst
+++ b/docs/debugging-instructions.rst
@@ -4,7 +4,7 @@ Debugging (VS Code)
 Debugging support described here is for Visual Studio Code. The Arduino IDE already provides a built-in debugger for supported boards.
 
 #. Install the `Cortex-Debug` extension in VS Code.
-#. Copy the `task_psoc6.json` file from `tools/vscode-profile` to the `.vscode` directory and rename it to `tasks.json` in your project root.
+#. Copy the `task_psoc.json` file from `tools/vscode-profile` to the `.vscode` directory and rename it to `tasks.json` in your project root.
 #. In VS Code, run the task: **Generate launch.json for debug (PSoC6)**.
 #. Required parameters for this task:
    * **fqbn**: Fully Qualified Board Name (e.g., `infineon:psoc6:cy8ckit_062s2_ai`)
@@ -13,6 +13,15 @@ Debugging support described here is for Visual Studio Code. The Arduino IDE alre
 #. Optional parameters:
    * **boards.txt path**: Path to a custom `boards.txt` file
    * **gdb path**: Path to a custom GDB executable
+
+Manual Usage
+------------
+
+You can also generate the `launch.json` file manually using the `gen_launch.sh` script:
+
+.. code-block:: bash
+
+   ./tools/gen_launch.sh --fqbn <board_fqbn> --build-path <path_to_build> --example-path <path_to_sketch> [--boards-txt <path_to_boards.txt>] [--gdb-path <path_to_gdb>]
 
 Refer to the documentation of your chosen debugger and scripts in the `tools/` folder for more details.
 

--- a/docs/debugging-instructions.rst
+++ b/docs/debugging-instructions.rst
@@ -1,0 +1,20 @@
+Debugging (VS Code)
+===================
+
+Debugging support described here is for Visual Studio Code. The Arduino IDE already provides a built-in debugger for supported boards.
+
+#. Install the `Cortex-Debug` extension in VS Code.
+#. Copy the `task_psoc6.json` file from `tools/vscode-profile` to the `.vscode` directory and rename it to `tasks.json` in your project root.
+#. In VS Code, run the task: **Generate launch.json for debug (PSoC6)**.
+#. Required parameters for this task:
+   * **fqbn**: Fully Qualified Board Name (e.g., `infineon:psoc6:cy8ckit_062s2_ai`)
+   * **build path**: Directory where the `.elf` file will be placed
+   * **example path**: Path to the sketch (`.ino` file) to debug (ensure it has been built at least once to generate the required build files)
+#. Optional parameters:
+   * **boards.txt path**: Path to a custom `boards.txt` file
+   * **gdb path**: Path to a custom GDB executable
+
+Refer to the documentation of your chosen debugger and scripts in the `tools/` folder for more details.
+
+.. note::
+   If you encounter an error indicating that ``libncurses.so.5`` or a similar library cannot be found, please search online and install the appropriate package for your environment.

--- a/tools/gen_launch.sh
+++ b/tools/gen_launch.sh
@@ -109,8 +109,7 @@ if [[ "$DEVICE_TYPE" == "psoc6" ]]; then
       "numberOfProcessors": 2,
       "targetProcessor": 1,// Set to 0 for the CM0+, set to 1 for the CM4
       "postStartSessionCommands": [
-        "monitor gdb_sync",
-        "stepi"
+        "continue"
       ],
       "overrideRestartCommands": [
         "starti"

--- a/tools/gen_launch.sh
+++ b/tools/gen_launch.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# gen_launch.sh: Compile and generate launch.json for XMC or PSoC6 boards
+# Usage: ./gen_launch.sh <fqbn> <build_path> <sketch_path> [boards.txt] [gdb_path]
+#   <fqbn>        : Fully Qualified Board Name (e.g. infineon:psoc6:CY8CKIT_062S2_AI or arduino-git:xmc:kit_xmc47_relax)
+#   <build_path>  : Directory where the .elf file will be placed
+#   <sketch_path> : Path to the sketch (.ino) file
+#   [boards.txt]  : (Optional) Path to boards.txt (default: inferred based on device)
+#   [gdb_path]    : (Optional) Path to GDB executable (default: inferred based on device)
+
+set -e
+
+FQBN_FULL="$1"
+BUILD_PATH="$2"
+SKETCH_PATH="$3"
+
+if [[ -z "$FQBN_FULL" || -z "$BUILD_PATH" || -z "$SKETCH_PATH" ]]; then
+  echo "Usage: $0 <fqbn> <build_path> <sketch_path> [boards.txt] [gdb_path]"
+  exit 1
+fi
+
+# Get the script directory and package root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Detect device type based on FQBN
+if [[ "$FQBN_FULL" == infineon:psoc6:* ]]; then
+  DEVICE_TYPE="psoc6"
+  BOARDS_TXT="${4:-$PACKAGE_DIR/boards.txt}"
+  GDB_PATH="${5:-$HOME/.arduino15/packages/infineon/tools/mtb-gcc-arm-none-eabi/11.3.1.67/bin/arm-none-eabi-gdb}"
+elif [[ "$FQBN_FULL" == arduino-git:xmc:* ]]; then
+  DEVICE_TYPE="xmc"
+  XMC_DIR="$(dirname "$SCRIPT_DIR")"
+  BOARDS_TXT="${4:-$XMC_DIR/boards.txt}"
+  GDB_PATH="${5:-$HOME/.arduino15/packages/infineon/tools/arm-none-eabi-gcc/10.3-2021.10/bin/arm-none-eabi-gdb}"
+else
+  echo "Unsupported device type in FQBN: $FQBN_FULL"
+  exit 1
+fi
+
+# Extract board name from FQBN
+BOARD_NAME=$(echo "$FQBN_FULL" | awk -F: '{print $NF}')
+
+# Compile the sketch
+arduino-cli compile -b "${FQBN_FULL}" --build-path "${BUILD_PATH}" "${SKETCH_PATH}" || exit 1
+
+# Parse boards.txt for variant and other parameters
+VARIANT=$(grep "^${BOARD_NAME}\.build\.variant=" "$BOARDS_TXT" | cut -d= -f2)
+if [[ -z "$VARIANT" ]]; then
+  echo "Could not find variant for $BOARD_NAME in $BOARDS_TXT"
+  exit 2
+fi
+
+if [[ "$DEVICE_TYPE" == "xmc" ]]; then
+  BOARD_V=$(grep "^${BOARD_NAME}\.build\.board\.v=" "$BOARDS_TXT" | cut -d= -f2)
+  if [[ -z "$BOARD_V" ]]; then
+    echo "Could not find board.v for $BOARD_NAME in $BOARDS_TXT"
+    exit 2
+  fi
+  DEVICE="${VARIANT}-${BOARD_V}"
+else
+  DEVICE="${VARIANT}"
+fi
+
+# Find the .elf executable
+EXECUTABLE=$(find "${BUILD_PATH}" -maxdepth 1 -type f -name "*.elf" | head -n 1)
+if [[ -z "$EXECUTABLE" ]]; then
+  echo "No .elf executable found in $BUILD_PATH."
+  exit 3
+fi
+
+# Create the .vscode directory and generate launch.json
+LAUNCH_DIR="$PACKAGE_DIR/.vscode"
+if [ ! -d "$LAUNCH_DIR" ]; then
+  mkdir -p "$LAUNCH_DIR"
+fi
+if [ -f "$LAUNCH_DIR/launch.json" ]; then
+  rm "$LAUNCH_DIR/launch.json"
+fi
+
+if [[ "$DEVICE_TYPE" == "psoc6" ]]; then
+  # Generate launch.json for PSoC6
+  cat > "$LAUNCH_DIR/launch.json" <<EOF
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+
+      "name": "Cortex-Debug: Debug ${DEVICE} CM4",
+      "type": "cortex-debug",
+      "request": "launch",
+      "servertype": "openocd",
+      "device": "${DEVICE}",
+      "executable": "${EXECUTABLE}",
+      "cwd": "\${workspaceFolder}",
+      "interface": "swd",
+      "gdbPath": "${GDB_PATH}",
+      "showDevDebugOutput": "vscode",
+      "configFiles": [
+        "$HOME/.arduino15/packages/infineon/tools/openocd/5.2.1.3248/scripts/interface/kitprog3.cfg",
+        "$HOME/.arduino15/packages/infineon/tools/openocd/5.2.1.3248/scripts/target/psoc6_2m.cfg"
+      ],
+      "overrideLaunchCommands": [
+        "set mem inaccessible-by-default off",
+        "-enable-pretty-printing",
+        "set remotetimeout 15",
+        "monitor reset run",
+        "monitor psoc6 reset_halt sysresetreq"
+      ],
+      "numberOfProcessors": 2,
+      "targetProcessor": 1,// Set to 0 for the CM0+, set to 1 for the CM4
+      "postStartSessionCommands": [
+        "monitor gdb_sync",
+        "stepi"
+      ],
+      "overrideRestartCommands": [
+        "starti"
+      ],
+      "postRestartSessionCommands": [],
+      "breakAfterReset": true
+    }
+  ]
+}
+EOF
+else
+  # Generate launch.json for XMC
+  cat > "$LAUNCH_DIR/launch.json" <<EOF
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Cortex-Debug: Debug ${DEVICE}",
+      "type": "cortex-debug",
+      "request": "launch",
+      "servertype": "jlink",
+      "device": "${DEVICE}",
+      "executable": "${EXECUTABLE}",
+      "cwd": "\${workspaceFolder}",
+      "interface": "swd",
+      "gdbPath": "${GDB_PATH}",
+      "showDevDebugOutput": "vscode"
+    }
+  ]
+}
+EOF
+fi
+
+echo "launch.json generated for ${DEVICE_TYPE} device ${DEVICE} at $LAUNCH_DIR."
+echo "(Using boards.txt at $BOARDS_TXT)"
+
+

--- a/tools/vscode_profile/task_psoc.json
+++ b/tools/vscode_profile/task_psoc.json
@@ -1,0 +1,114 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+	  {
+		"label": "Arduino Build",
+		"type": "shell",
+		"command": "arduino-cli",
+		"args": [
+		  "compile",
+		  "--fqbn", "${input:boardFqbn}",
+		  "${input:examplePath}"
+		],
+		"group": {
+		  "kind": "build",
+		  "isDefault": false
+		},
+		"problemMatcher": []
+	  },
+	  {
+		"label": "Arduino Upload",
+		"type": "shell",
+		"command": "arduino-cli",
+		"args": [
+		  "upload",
+		//  "--verbose",
+		  "-p", "${input:port}",
+		  "--fqbn", "${input:boardFqbn}",
+		  "${input:examplePath}"
+		],
+		"dependsOn": "Arduino Build",
+		"group": {
+		  "kind": "build",
+		  "isDefault": true
+		},
+		"problemMatcher": []
+	  },
+		{
+			"label": "Generate lauch.json for debug (PSOC)",
+			"type": "shell",
+			"command": "${workspaceFolder}/tools/gen_launch.sh",
+			"args": [
+				"${input:boardFqbn}",
+				"${input:debugBuildPath}",
+				"${input:examplePath}",
+				"${input:boardsTxtPath}",
+				"${input:gdbPath}"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
+			},
+			"problemMatcher": [],
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "shared"
+			}
+		},
+		{
+			"label": "Arduino Monitor",
+			"type": "shell",
+			"command": "arduino-cli",
+			"args": [
+				"monitor",
+				"-p", "${input:port}",
+				"-c", "baudrate=115200"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
+			},
+			"problemMatcher": []
+			}
+	],
+	"inputs": [
+			{
+				"id": "boardFqbn",
+				"type": "promptString",
+				"description": "Enter the FQBN (Fully Qualified Board Name) for the Arduino board",
+				"default": "infineon:psoc6:cy8ckit_062s2_ai"
+			},
+				{
+					"id": "debugBuildPath",
+					"type": "promptString",
+					"description": "Enter the build path where the .elf file would be placed",
+					"default": "${workspaceFolder}/extras/arduino-core-tests/build/output"
+				},
+		{
+			"id": "examplePath",
+			"type": "promptString",
+			"description": "Enter the path to the Arduino example sketch",
+			"default": "${workspaceFolder}/examples/bug/bug.ino"
+		},
+		{
+			"id": "port",
+			"type": "promptString",
+			"description": "Enter the port for the Arduino board",
+			"default": "/dev/ttyACM0"
+		},
+		{
+			"id": "boardsTxtPath",
+			"type": "promptString",
+			"description": "(Optional) Enter the path to boards.txt, or leave blank for default",
+			"default": ""
+		},
+		{
+			"id": "gdbPath",
+			"type": "promptString",
+			"description": "(Optional) Enter the path to arm-none-eabi-gdb, or leave blank for default",
+			"default": ""
+		},
+	]
+  }

--- a/tools/vscode_profile/task_psoc.json
+++ b/tools/vscode_profile/task_psoc.json
@@ -22,7 +22,6 @@
 		"command": "arduino-cli",
 		"args": [
 		  "upload",
-		//  "--verbose",
 		  "-p", "${input:port}",
 		  "--fqbn", "${input:boardFqbn}",
 		  "${input:examplePath}"
@@ -35,7 +34,7 @@
 		"problemMatcher": []
 	  },
 		{
-			"label": "Generate lauch.json for debug (PSOC)",
+			"label": "Generate launch.json for debug (PSOC)",
 			"type": "shell",
 			"command": "${workspaceFolder}/tools/gen_launch.sh",
 			"args": [
@@ -109,6 +108,6 @@
 			"type": "promptString",
 			"description": "(Optional) Enter the path to arm-none-eabi-gdb, or leave blank for default",
 			"default": ""
-		},
+		}
 	]
   }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---
This branch added files to integrate cortex-debugger in arduino-core-psoc6, after installing the cortex-debugger extension in vscode and copy and rename the tasks.json under .vscode, the Cortex-debugger can be directly run.