### PR TITLE
Feature/add dev container

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,11 +7,18 @@ privileged mode enabled so board tools and USB access can work from inside the
 container. Dev Containers updates the `vscode` UID/GID to match the local
 workspace owner, which keeps bind-mounted file ownership aligned with the host.
 
+The container image is built from the Dockerfile in the `extras/makers-docker` Git submodule.
+
 ## How to use
 
-1. In VS Code, run "Dev Containers: Reopen in Container" or "Open Folder in Container...".
-2. Select the repository root and let the container build.
-3. The `postCreateCommand` runs automatically and executes the repo setup scripts.
+1. **Initialize submodules** (first time only):
+   ```sh
+   git submodule update --init --recursive
+   ```
+
+2. In VS Code, run "Dev Containers: Reopen in Container" or "Open Folder in Container...".
+3. Select the repository root and let the container build.
+4. The `postCreateCommand` runs automatically and executes the repo setup scripts.
 
 If you need to rerun the setup manually from the repository root:
 
@@ -29,15 +36,46 @@ bash .devcontainer/scripts/dev-setup.sh
 
 ## What the setup does
 
-The container bootstrap performs the following:
+The container bootstrap runs the following scripts in order:
 
-- `git-setup.sh`: verifies Git.
-- `usb-check.sh`: checks whether serial devices and `/dev/bus/usb` are visible from inside the container.
-- `dev-setup.sh`: runs `tools/dev-setup.sh`, checks for `arduino-cli`, and links the repo into the Arduino sketchbook hardware path so this checkout can be used as a local Arduino core.
+1. **`scripts/git-setup.sh`** — Verifies Git is available and working.
+2. **`scripts/usb-set-kitprog3.sh`** — Configures USB permissions for KitProg3 programmers (Cypress/Infineon boards).
+3. **`scripts/usb-check.sh`** — Diagnoses USB device visibility (serial ports and USB bus access).
+4. **`scripts/dev-setup.sh`** — Runs core setup, checks Arduino CLI, and links the repo as a local Arduino core.
 
-Use `git-setup.sh` after changing Git credentials or submodule state, `usb-check.sh`
-when attaching a board or troubleshooting serial/USB access, and `dev-setup.sh`
-after changing the core, Arduino CLI, or sketchbook configuration.
+### When to run individual scripts:
+
+- **After changing Git credentials or submodule state:** `bash .devcontainer/scripts/git-setup.sh`
+- **When attaching a board or troubleshooting serial/USB access:** `bash .devcontainer/scripts/usb-check.sh`
+- **After changing the core, Arduino CLI, or sketchbook configuration:** `bash .devcontainer/scripts/dev-setup.sh`
+
+See the comments in each script for implementation details.
+
+## Configuration Reference
+
+The `devcontainer.json` file contains the following configuration options:
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| **name** | `PSOC6 Arduino Core (makers-docker)` | Display name shown in VS Code |
+| **dockerFile** | `../extras/makers-docker/Dockerfile.test` | Path to the Dockerfile in the makers-docker submodule used to build the container image |
+| **workspaceFolder** | `/myLocalWorkingDir` | Mount point for the repository inside the container |
+| **workspaceMount** | Bind source with `consistency=cached` | Mounts the host workspace into the container with optimized performance on macOS/WSL |
+| **remoteUser** | `vscode` | User that VS Code connects as when attached to the container |
+| **updateRemoteUserUID** | `true` | Automatically updates the `vscode` user's UID/GID to match the host user, ensuring file permissions are aligned |
+| **features** | `common-utils:2` with `username=vscode` | Installs common devcontainer utilities for the `vscode` user |
+| **privileged** | `true` | Enables privileged mode so the container can access USB devices and board programmers |
+| **mounts** | `/dev` → `/dev`, `$HOME/.ssh` → `/home/vscode/.ssh` | Exposes host device files and SSH keys to the container |
+| **runArgs** | `--init` | Runs the container with PID 1 init process (proper signal handling) |
+| **postCreateCommand** | `bash .devcontainer/post-create.sh` | Runs setup scripts automatically after the container is created |
+| **customizations.vscode.extensions** | C/C++, Python, Pylance | VS Code extensions installed in the container |
+
+### Key configuration notes:
+
+- **`remoteUser` + `updateRemoteUserUID`** — Ensures the container user matches the host user, preventing permission issues with bind-mounts.
+- **`privileged`** — Required for USB device access (programmers, serial ports). Should only be used with trusted Dockerfiles.
+- **`mounts`** — `/dev` binding enables direct access to hardware; SSH key binding supports Git/remote operations without credential re-entry.
+- **`workspaceMount`** — `consistency=cached` improves performance on Docker Desktop (macOS/Windows) by reducing sync overhead.
 
 ## Notes
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,46 @@
+# Dev Container Setup
+
+This repository uses the default dev container configuration in `devcontainer.json`.
+It runs with the project workspace mounted at `/myLocalWorkingDir`, the host `/dev`
+ tree bound into the container, and privileged mode enabled so board tools and USB
+ access can work from inside the container.
+
+## How to use
+
+1. In VS Code, run "Dev Containers: Reopen in Container" or "Open Folder in Container...".
+2. Select the repository root and let the container build.
+3. The `postCreateCommand` runs automatically and executes the repo setup scripts.
+
+If you need to rerun the setup manually from the repository root:
+
+```sh
+bash .devcontainer/post-create.sh
+```
+
+You can also run the individual steps directly:
+
+```sh
+bash .devcontainer/scripts/git-setup.sh
+bash .devcontainer/scripts/usb-check.sh
+bash .devcontainer/scripts/dev-setup.sh
+```
+
+## What the setup does
+
+The container bootstrap performs the following:
+
+- `git-setup.sh`: verifies Git, adds the repo to the safe.directory list, imports SSH config/known_hosts when an agent is forwarded, and initializes submodules.
+- `usb-check.sh`: checks whether serial devices and `/dev/bus/usb` are visible from inside the container.
+- `dev-setup.sh`: runs `tools/dev-setup.sh`, checks for `arduino-cli`, and links the repo into the Arduino sketchbook hardware path so this checkout can be used as a local Arduino core.
+
+Use `git-setup.sh` after changing Git credentials or submodule state, `usb-check.sh`
+when attaching a board or troubleshooting serial/USB access, and `dev-setup.sh`
+after changing the core, Arduino CLI, or sketchbook configuration.
+
+## Notes
+
+- The dev container uses the makers Docker image and includes Git support.
+- SSH forwarding is optional; without a host SSH agent, HTTPS Git remotes still work.
+- The default container is intentionally privileged and binds `/dev` to support USB serial devices and board programming workflows.
+- If `/dev/bus/usb` or `/dev/ttyACM*` devices are not visible, verify the host exposes them and reopen the container after attaching the board.
+- On WSL, attach boards with `usbipd.exe attach --wsl --busid <BUSID>` before reopening the container. On native Linux, ensure the host user can access the board and that the relevant USB devices are exposed to the container.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,9 +1,11 @@
 # Dev Container Setup
 
 This repository uses the default dev container configuration in `devcontainer.json`.
-It runs with the project workspace mounted at `/myLocalWorkingDir`, the host `/dev`
- tree bound into the container, and privileged mode enabled so board tools and USB
- access can work from inside the container.
+It runs as the non-root `vscode` user with the project workspace mounted at
+`/myLocalWorkingDir`, the host `/dev` tree bound into the container, and
+privileged mode enabled so board tools and USB access can work from inside the
+container. Dev Containers updates the `vscode` UID/GID to match the local
+workspace owner, which keeps bind-mounted file ownership aligned with the host.
 
 ## How to use
 
@@ -29,7 +31,7 @@ bash .devcontainer/scripts/dev-setup.sh
 
 The container bootstrap performs the following:
 
-- `git-setup.sh`: verifies Git, adds the repo to the safe.directory list, imports SSH config/known_hosts when an agent is forwarded, and initializes submodules.
+- `git-setup.sh`: verifies Git.
 - `usb-check.sh`: checks whether serial devices and `/dev/bus/usb` are visible from inside the container.
 - `dev-setup.sh`: runs `tools/dev-setup.sh`, checks for `arduino-cli`, and links the repo into the Arduino sketchbook hardware path so this checkout can be used as a local Arduino core.
 
@@ -40,7 +42,7 @@ after changing the core, Arduino CLI, or sketchbook configuration.
 ## Notes
 
 - The dev container uses the makers Docker image and includes Git support.
-- SSH forwarding is optional; without a host SSH agent, HTTPS Git remotes still work.
+- The container runs as `vscode`; host SSH keys are mounted at `/home/vscode/.ssh`.
 - The default container is intentionally privileged and binds `/dev` to support USB serial devices and board programming workflows.
 - If `/dev/bus/usb` or `/dev/ttyACM*` devices are not visible, verify the host exposes them and reopen the container after attaching the board.
-- On WSL, attach boards with `usbipd.exe attach --wsl --busid <BUSID>` before reopening the container. On native Linux, ensure the host user can access the board and that the relevant USB devices are exposed to the container.
+- On WSL, attach boards with `usbipd attach --wsl --busid <BUSID>` before reopening the container. On native Linux, ensure the host user can access the board and that the relevant USB devices are exposed to the container.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -39,7 +39,7 @@ bash .devcontainer/scripts/dev-setup.sh
 The container bootstrap runs the following scripts in order:
 
 1. **`scripts/git-setup.sh`** — Verifies Git is available and working.
-2. **`scripts/usb-set-kitprog3.sh`** — Configures USB permissions for KitProg3 programmers (Cypress/Infineon boards).
+2. **`scripts/usb-set-usb-permissions.sh`** — Configures USB permissions for KitProg3 programmers (Cypress/Infineon boards) and Arduino Uno boards.
 3. **`scripts/usb-check.sh`** — Diagnoses USB device visibility (serial ports and USB bus access).
 4. **`scripts/dev-setup.sh`** — Runs core setup, checks Arduino CLI, and links the repo as a local Arduino core.
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,7 +2,7 @@
 
 This repository uses the default dev container configuration in `devcontainer.json`.
 It runs as the non-root `vscode` user with the project workspace mounted at
-`/myLocalWorkingDir`, the host `/dev` tree bound into the container, and
+`/home/vscode/myLocalWorkingDir`, the host `/dev` tree bound into the container, and
 privileged mode enabled so board tools and USB access can work from inside the
 container. Dev Containers updates the `vscode` UID/GID to match the local
 workspace owner, which keeps bind-mounted file ownership aligned with the host.
@@ -59,7 +59,7 @@ The `devcontainer.json` file contains the following configuration options:
 |--------|-------|---------|
 | **name** | `PSOC6 Arduino Core (makers-docker)` | Display name shown in VS Code |
 | **dockerFile** | `../extras/makers-docker/Dockerfile.test` | Path to the Dockerfile in the makers-docker submodule used to build the container image |
-| **workspaceFolder** | `/myLocalWorkingDir` | Mount point for the repository inside the container |
+| **workspaceFolder** | `/home/vscode/myLocalWorkingDir` | Mount point for the repository inside the container |
 | **workspaceMount** | Bind source with `consistency=cached` | Mounts the host workspace into the container with optimized performance on macOS/WSL |
 | **remoteUser** | `vscode` | User that VS Code connects as when attached to the container |
 | **updateRemoteUserUID** | `true` | Automatically updates the `vscode` user's UID/GID to match the host user, ensuring file permissions are aligned |

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "PSOC6 Arduino Core (makers-docker)",
-  "dockerFile": "../../makers-docker/Dockerfile.test",
+  "dockerFile": "../extras/makers-docker/Dockerfile.test",
   "workspaceFolder": "/myLocalWorkingDir",
   "workspaceMount": "source=${localWorkspaceFolder},target=/myLocalWorkingDir,type=bind,consistency=cached",
   "containerUser": "vscode",
@@ -11,13 +11,13 @@
       "username": "vscode"
     }
   },
+  "privileged": true,
   "mounts": [
     "source=/dev,target=/dev,type=bind",
     "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
   ],
   "runArgs": [
-    "--init",
-    "--privileged"
+    "--init"
   ],
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,17 @@
   "dockerFile": "../../makers-docker/Dockerfile.test",
   "workspaceFolder": "/myLocalWorkingDir",
   "workspaceMount": "source=${localWorkspaceFolder},target=/myLocalWorkingDir,type=bind,consistency=cached",
+  "containerUser": "vscode",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "vscode"
+    }
+  },
   "mounts": [
     "source=/dev,target=/dev,type=bind",
-    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
   ],
   "runArgs": [
     "--init",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "PSOC6 Arduino Core (makers-docker)",
+  "dockerFile": "../../makers-docker/Dockerfile.test",
+  "workspaceFolder": "/myLocalWorkingDir",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/myLocalWorkingDir,type=bind,consistency=cached",
+  "mounts": [
+    "source=/dev,target=/dev,type=bind",
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+  ],
+  "runArgs": [
+    "--init",
+    "--privileged"
+  ],
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
     }
   },
   "privileged": true,
+  "containerEnv": {
+    "ARDUINO_DIRECTORIES_DATA": "/opt/.arduino15"
+  },
   "mounts": [
     "source=/dev,target=/dev,type=bind",
     "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
@@ -25,7 +28,9 @@
       "extensions": [
         "ms-vscode.cpptools",
         "ms-python.python",
-        "ms-python.vscode-pylance"
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "charliermarsh.ruff"
       ]
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
   "name": "PSOC6 Arduino Core (makers-docker)",
   "dockerFile": "../extras/makers-docker/Dockerfile.test",
-  "workspaceFolder": "/myLocalWorkingDir",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/myLocalWorkingDir,type=bind,consistency=cached",
+  "workspaceFolder": "/home/vscode/myLocalWorkingDir",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/myLocalWorkingDir,type=bind,consistency=cached",
   "containerUser": "vscode",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
+# Post-create hook: runs all devcontainer setup scripts in order
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-bash "$script_dir/scripts/git-setup.sh"
+# Initialize USB, and development environment
+bash "$script_dir/scripts/usb-set-kitprog3.sh"
 bash "$script_dir/scripts/usb-check.sh"
 bash "$script_dir/scripts/dev-setup.sh"
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+bash "$script_dir/scripts/git-setup.sh"
+bash "$script_dir/scripts/usb-check.sh"
+bash "$script_dir/scripts/dev-setup.sh"
+
+echo "[devcontainer] Setup complete."

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,9 +4,11 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-# Initialize USB, and development environment
-bash "$script_dir/scripts/usb-set-kitprog3.sh"
+# Initialize USB, install repo tooling, and configure local development environment.
+bash "$script_dir/scripts/usb-set-usb-permissions.sh"
 bash "$script_dir/scripts/usb-check.sh"
+bash "$script_dir/scripts/arduino-user-data-dir.sh"
+bash "$script_dir/scripts/dev-tools.sh"
 bash "$script_dir/scripts/dev-setup.sh"
 
 echo "[devcontainer] Setup complete."

--- a/.devcontainer/scripts/arduino-user-data-dir.sh
+++ b/.devcontainer/scripts/arduino-user-data-dir.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verify that Arduino CLI's configured data directory is accessible, so
+# existing and later-installed cores/tools share one supported location.
+set -euo pipefail
+
+data_dir="${ARDUINO_DIRECTORIES_DATA:?ARDUINO_DIRECTORIES_DATA must be set}"
+
+mkdir -p "$data_dir"
+
+# Ensure the active user can actually read/write the shared Arduino data area,
+# including any subdirs (e.g. staging/libraries) created earlier as root.
+user_name="$(id -un)"
+user_group="$(id -gn)"
+current_owner="$(stat -c '%U:%G' "$data_dir" 2>/dev/null || true)"
+
+if [[ "$current_owner" != "$user_name:$user_group" ]]; then
+	if ! chown -R "$user_name:$user_group" "$data_dir" 2>/dev/null; then
+		if command -v sudo >/dev/null 2>&1; then
+			sudo chown -R "$user_name:$user_group" "$data_dir"
+		else
+			echo "[devcontainer] Could not grant ownership of Arduino data directory to $user_name: $data_dir" >&2
+			exit 1
+		fi
+	fi
+	chmod -R u+rwX "$data_dir" 2>/dev/null || {
+		if command -v sudo >/dev/null 2>&1; then
+			sudo chmod -R u+rwX "$data_dir"
+		fi
+	}
+fi
+
+if [[ ! -r "$data_dir" || ! -w "$data_dir" || ! -x "$data_dir" ]]; then
+	echo "[devcontainer] Arduino CLI data directory is not accessible: $data_dir" >&2
+	exit 1
+fi
+
+echo "[devcontainer] Arduino CLI data directory ready at $data_dir."

--- a/.devcontainer/scripts/dev-setup.sh
+++ b/.devcontainer/scripts/dev-setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+echo "[devcontainer] Running core setup..."
+bash tools/dev-setup.sh
+
+if command -v python3 >/dev/null 2>&1; then
+  python3 --version
+fi
+
+echo "[devcontainer] Checking Arduino CLI..."
+if ! command -v arduino-cli >/dev/null 2>&1; then
+  echo "[devcontainer] WARNING: arduino-cli is not installed in the container."
+  echo "[devcontainer] Install it inside the container to compile/upload sketches."
+  exit 0
+fi
+
+arduino-cli version
+sketchbook_dir="$(arduino-cli config get directories.user)"
+arduino_git_dir="${sketchbook_dir}/hardware/arduino-git"
+mkdir -p "$arduino_git_dir"
+ln -sfn "$repo_root" "$arduino_git_dir/psoc6"
+echo "[devcontainer] Linked $arduino_git_dir/psoc6 -> $repo_root"

--- a/.devcontainer/scripts/dev-setup.sh
+++ b/.devcontainer/scripts/dev-setup.sh
@@ -1,24 +1,16 @@
 #!/usr/bin/env bash
+# Set up the development environment: run repo setup, configure Arduino, and link PSoC6 core
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$repo_root"
 
+# Run the main repository setup script
 echo "[devcontainer] Running core setup..."
 bash tools/dev-setup.sh
 
-if command -v python3 >/dev/null 2>&1; then
-  python3 --version
-fi
-
-echo "[devcontainer] Checking Arduino CLI..."
-if ! command -v arduino-cli >/dev/null 2>&1; then
-  echo "[devcontainer] WARNING: arduino-cli is not installed in the container."
-  echo "[devcontainer] Install it inside the container to compile/upload sketches."
-  exit 0
-fi
-
 arduino-cli version
+# Link the repo into Arduino's hardware directory so it can be used as a local core
 sketchbook_dir="$(arduino-cli config get directories.user)"
 arduino_git_dir="${sketchbook_dir}/hardware/arduino-git"
 mkdir -p "$arduino_git_dir"

--- a/.devcontainer/scripts/dev-setup.sh
+++ b/.devcontainer/scripts/dev-setup.sh
@@ -10,9 +10,21 @@ echo "[devcontainer] Running core setup..."
 bash tools/dev-setup.sh
 
 arduino-cli version
-# Link the repo into Arduino's hardware directory so it can be used as a local core
-sketchbook_dir="$(arduino-cli config get directories.user)"
-arduino_git_dir="${sketchbook_dir}/hardware/arduino-git"
-mkdir -p "$arduino_git_dir"
-ln -sfn "$repo_root" "$arduino_git_dir/psoc6"
-echo "[devcontainer] Linked $arduino_git_dir/psoc6 -> $repo_root"
+
+# Replace the installed core with this checkout while retaining its installed version.
+psoc6_version="$(arduino-cli core list | awk '$1 == "infineon:psoc6" { print $2; exit }')"
+if [[ -z "$psoc6_version" ]]; then
+	echo "[devcontainer] infineon:psoc6 is not installed" >&2
+	exit 1
+fi
+
+arduino_data_dir="$(arduino-cli config get directories.data)"
+installed_core_dir="${arduino_data_dir}/packages/infineon/hardware/psoc6/${psoc6_version}"
+if [[ ! -d "$installed_core_dir" ]]; then
+	echo "[devcontainer] Installed core directory not found: $installed_core_dir" >&2
+	exit 1
+fi
+
+sudo rm -rf "$installed_core_dir"
+sudo ln -s "$repo_root" "$installed_core_dir"
+echo "[devcontainer] Linked $installed_core_dir -> $repo_root"

--- a/.devcontainer/scripts/dev-tools.sh
+++ b/.devcontainer/scripts/dev-tools.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Install the repo's required tooling for git hooks and local formatting.
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+if ! command -v uncrustify >/dev/null 2>&1; then
+    echo "[devcontainer] Installing uncrustify..."
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends uncrustify
+fi
+
+if ! command -v pre-commit >/dev/null 2>&1; then
+    echo "[devcontainer] Installing pre-commit..."
+    sudo python3 -m pip install --break-system-packages pre-commit
+fi
+
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+
+echo "[devcontainer] Git hooks and formatter dependencies are ready."

--- a/.devcontainer/scripts/git-setup.sh
+++ b/.devcontainer/scripts/git-setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+echo "[devcontainer] Checking Git access..."
+git --version

--- a/.devcontainer/scripts/git-setup.sh
+++ b/.devcontainer/scripts/git-setup.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-cd "$repo_root"
-
-echo "[devcontainer] Checking Git access..."
-git --version

--- a/.devcontainer/scripts/usb-check.sh
+++ b/.devcontainer/scripts/usb-check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[devcontainer] Checking USB access..."
+
+if command -v lsusb >/dev/null 2>&1; then
+  echo "[devcontainer] USB devices visible to the container:"
+  lsusb || true
+else
+  echo "[devcontainer] NOTICE: lsusb is unavailable; install usbutils for USB diagnostics."
+fi
+
+serial_devices=()
+for device_pattern in /dev/ttyACM* /dev/ttyUSB*; do
+  [[ -e "$device_pattern" ]] && serial_devices+=("$device_pattern")
+done
+
+if ((${#serial_devices[@]} > 0)); then
+  echo "[devcontainer] Serial devices visible: ${serial_devices[*]}"
+else
+  echo "[devcontainer] NOTICE: No /dev/ttyACM* or /dev/ttyUSB* devices are visible."
+fi
+
+if [[ -d /dev/bus/usb ]]; then
+  echo "[devcontainer] USB bus is mounted at /dev/bus/usb."
+else
+  echo "[devcontainer] NOTICE: /dev/bus/usb is unavailable; use hardware mode for USB passthrough."
+fi

--- a/.devcontainer/scripts/usb-check.sh
+++ b/.devcontainer/scripts/usb-check.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
+# Diagnose USB device visibility (serial ports and USB bus access)
 set -euo pipefail
 
 echo "[devcontainer] Checking USB access..."
 
+# List USB devices if lsusb is available
 if command -v lsusb >/dev/null 2>&1; then
   echo "[devcontainer] USB devices visible to the container:"
   lsusb || true
@@ -10,6 +12,7 @@ else
   echo "[devcontainer] NOTICE: lsusb is unavailable; install usbutils for USB diagnostics."
 fi
 
+# Check for serial device files (ACM and USB serial adapters)
 serial_devices=()
 for device_pattern in /dev/ttyACM* /dev/ttyUSB*; do
   [[ -e "$device_pattern" ]] && serial_devices+=("$device_pattern")
@@ -21,6 +24,7 @@ else
   echo "[devcontainer] NOTICE: No /dev/ttyACM* or /dev/ttyUSB* devices are visible."
 fi
 
+# Check if USB bus filesystem is mounted (required for raw USB access)
 if [[ -d /dev/bus/usb ]]; then
   echo "[devcontainer] USB bus is mounted at /dev/bus/usb."
 else

--- a/.devcontainer/scripts/usb-set-kitprog3.sh
+++ b/.devcontainer/scripts/usb-set-kitprog3.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Configure USB permissions for KitProg3 programmer (Cypress/Infineon boards)
+set -euo pipefail
+
+# Find KitProg3 devices by USB vendor:product ID (04b4:f155)
+kitprog_devices=()
+while read -r device_path; do
+  [[ -e "$device_path" ]] && kitprog_devices+=("$device_path")
+done < <(
+  lsusb | awk '$6 == "04b4:f155" {
+    printf "/dev/bus/usb/%s/%s\n", $2, substr($4, 1, 3)
+  }'
+)
+
+if ((${#kitprog_devices[@]} == 0)); then
+  echo "[devcontainer] No KitProg3 devices found."
+  exit 0
+fi
+
+# Find serial device files associated with the programmer
+serial_devices=()
+for device_path in /dev/ttyACM*; do
+  [[ -e "$device_path" ]] && serial_devices+=("$device_path")
+done
+
+# Grant read/write access to the container user
+sudo chmod a+rw "${kitprog_devices[@]}" "${serial_devices[@]}"
+echo "[devcontainer] KitProg3 USB access configured."

--- a/.devcontainer/scripts/usb-set-usb-permissions.sh
+++ b/.devcontainer/scripts/usb-set-usb-permissions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Configure USB permissions for supported programmers and Arduino boards
+set -euo pipefail
+
+# Find supported USB devices by vendor:product ID.
+# 04b4:f155: KitProg3 programmer
+# 2341:1002: Arduino Uno
+kitprog_devices=()
+while read -r device_path; do
+  [[ -e "$device_path" ]] && kitprog_devices+=("$device_path")
+done < <(
+  lsusb | awk '$6 == "04b4:f155" || $6 == "2341:1002" {
+    printf "/dev/bus/usb/%s/%s\n", $2, substr($4, 1, 3)
+  }'
+)
+
+if ((${#kitprog_devices[@]} == 0)); then
+  echo "[devcontainer] No supported USB devices found."
+  exit 0
+fi
+
+# Find serial device files associated with the programmer
+serial_devices=()
+for device_path in /dev/ttyACM*; do
+  [[ -e "$device_path" ]] && serial_devices+=("$device_path")
+done
+
+# Grant read/write access to the container user
+sudo chmod a+rw "${kitprog_devices[@]}" "${serial_devices[@]}"
+echo "[devcontainer] USB access configured for supported devices."

--- a/.gitmodules
+++ b/.gitmodules
@@ -91,4 +91,7 @@
 [submodule "extras/mtb-libs/recipe-make-cat1a"]
 	path = extras/mtb-libs/recipe-make-cat1a
 	url = https://github.com/Infineon/recipe-make-cat1a.git
+[submodule "extras/makers-docker"]
+	path = extras/makers-docker
+	url = https://github.com/Infineon/makers-docker.git
 	


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Add devcontainer setup for arduino core psoc6.
Check this tutorial:
https://code.visualstudio.com/docs/devcontainers/tutorial
to install and use it. should work oob.

Related Issue
N/A

Context
Reuse makers-docker for devcontainer setup - same dockerfile for cicd and local development. 
Save time of developer for env setup.
And also, this is a “document” containing development environment settings that are updated in sync with the code.
It's worth considering whether devcontainers can be used to manage the environment in new projects (such as ArduinoCore Zephyr. I checked some doc anusha has, really very inspiring. Like this: https://confluencewikiprod.intra.infineon.com/spaces/ARDUINO/pages/3657467425/PSOC+Edge+Arduino+Zephyr+Core+Developer+Setup#PSOCEdgeArduinoZephyrCoreDeveloperSetup-6.4LocalDevelopment. Different than what I did in this .devcontainer and might be a better solution). 